### PR TITLE
Import external vernacular names into taxonomy merger

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,17 @@ To use ala-name-matching, include it as a dependency in your pom file:
    </dependency>
 ```
 
+If you are using grails 3, you may encounter problems with the newer GBIF
+libraries having validation code that conflicts with spring validation.
+You can correct this by using
+
+```
+compile("au.org.ala:ala-name-matching:2.4.6") {
+    exclude group: 'org.slf4j', module: 'slf4j-log4j12'
+    exclude group: 'org.apache.bval', module: 'org.apache.bval.bundle'
+}
+```
+
 Download the most recently generated name matching index: 
 
 http://biocache.ala.org.au/archives/namematching/YYYMMDD/namematching-YYYMMDD.tgz

--- a/src/main/java/au/org/ala/names/index/ALANameAnalyser.java
+++ b/src/main/java/au/org/ala/names/index/ALANameAnalyser.java
@@ -150,10 +150,10 @@ public class ALANameAnalyser extends NameAnalyser {
      * @param rankType                 The taxon rank
      * @param loose                    This is from a loose source that may have authors mixed up with names
      *
-     * @return
+     * @return The analyzed name
      */
     @Override
-    public NameKey analyse(NomenclaturalCode code, String scientificName, @Nullable String scientificNameAuthorship, @Nullable RankType rankType, boolean loose) {
+    public NameKey analyse(@Nullable NomenclaturalCode code, String scientificName, @Nullable String scientificNameAuthorship, @Nullable RankType rankType, boolean loose) {
         NameType nameType = NameType.INFORMAL;
         if (scientificNameAuthorship != null && scientificName.endsWith(scientificNameAuthorship)) {
             scientificName = scientificName.substring(0, scientificName.length() - scientificNameAuthorship.length()).trim();
@@ -502,15 +502,26 @@ public class ALANameAnalyser extends NameAnalyser {
             return cmp;
         if ((cmp = key1.getRank().compareTo(key2.getRank())) != 0)
             return cmp;
-        if (key1.getScientificNameAuthorship() == null && key2.getScientificNameAuthorship() == null)
+        return this.compareAuthor(key1.getScientificNameAuthorship(), key2.getScientificNameAuthorship());
+    }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Use the GBIF name comparator fdr equality
+     * </p>
+     */
+    @Override
+    public int compareAuthor(String author1, String author2) {
+        if (author1 == null && author2 == null)
             return 0;
-        if (key1.getScientificNameAuthorship() == null && key2.getScientificNameAuthorship() != null)
+        if (author1 == null && author2 != null)
             return -1;
-        if (key1.getScientificNameAuthorship() != null && key2.getScientificNameAuthorship() == null)
+        if (author1 != null && author2 == null)
             return 1;
-        if (authorComparator.compare(key1.getScientificNameAuthorship(), null, key2.getScientificNameAuthorship(), null) == Equality.EQUAL)
+        if (authorComparator.compare(author1, null, author2, null) == Equality.EQUAL)
             return 0;
-        return key1.getScientificNameAuthorship().compareTo(key2.getScientificNameAuthorship());
+        return author1.compareTo(author2);
     }
 
     /**

--- a/src/main/java/au/org/ala/names/index/BareName.java
+++ b/src/main/java/au/org/ala/names/index/BareName.java
@@ -1,5 +1,8 @@
 package au.org.ala.names.index;
 
+import au.org.ala.names.model.RankType;
+import org.gbif.api.vocabulary.NomenclaturalCode;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -122,8 +125,6 @@ public class BareName extends Name<BareName, BareName, UnrankedScientificName> {
         }
         element.clear(principal);
     }
-
-
 
     /**
      * A human readbale label for the concept

--- a/src/main/java/au/org/ala/names/index/DwcaNameSource.java
+++ b/src/main/java/au/org/ala/names/index/DwcaNameSource.java
@@ -11,6 +11,7 @@ import org.gbif.api.model.registry.Citation;
 import org.gbif.api.model.registry.Contact;
 import org.gbif.api.model.registry.Dataset;
 import org.gbif.api.vocabulary.*;
+import org.gbif.dwc.terms.GbifTerm;
 import org.gbif.dwca.io.MetadataException;
 import org.gbif.dwca.record.Record;
 import org.gbif.dwca.record.StarRecord;
@@ -166,10 +167,67 @@ public class DwcaNameSource extends NameSource {
      */
     @Override
     public void loadIntoTaxonomy(Taxonomy taxonomy) throws IndexBuilderException {
+         if (archive.getCore().getRowType() == DwcTerm.Taxon)
+            this.loadTaxonDwCA(taxonomy);
+        else if (archive.getCore().getRowType() == GbifTerm.VernacularName)
+            this.loadVernacularDwCA(taxonomy);
+        else
+            throw new IndexBuilderException("Unable to load from archive of type " + archive.getCore().getRowType());
+     }
+
+    /**
+     * Load a vernacular DwCA.
+     * <p>
+     * This is often a DwCA with "free-floating" vernacular names, usually keyed to a scientific name or classification.
+     * Unless they have a specific taxonID, they will, eventually, be linked to the most likely taxon.
+     * </p>
+     *
+     * @param taxonomy The taxonomy
+     *
+     * @throws IndexBuilderException if unable to load a record into the taxonomy.
+     */
+    public void loadVernacularDwCA(Taxonomy taxonomy) throws IndexBuilderException {
+        taxonomy.addOutputTerms(archive.getCore().getRowType(), archive.getCore().getTerms());
+        String taxonID = null;
+        Term type = null;
+        for (ArchiveFile ext: archive.getExtensions())
+            taxonomy.addOutputTerms(ext.getRowType(), ext.getTerms());
+        try {
+            for (StarRecord record : this.archive) {
+                Record core = record.core();
+                taxonID = core.value(DwcTerm.taxonID);
+                type = core.rowType();
+                if (taxonID == null) {
+                    taxonID = UUID.randomUUID().toString();
+                    type = ALATerm.UplacedVernacularName;
+                }
+                List<Document> docs = new ArrayList<>();
+                docs.add(this.makeDocument(taxonomy, type, core, taxonID));
+                for (List<Record> ext: record.extensions().values()) {
+                    for (Record er: ext) {
+                        docs.add(makeDocument(taxonomy, er.rowType(), er, taxonID));
+                    }
+                }
+                taxonomy.addRecords(docs);
+            }
+        } catch (Exception ex) {
+            throw new IndexBuilderException("Unable to load archive " + this.archive.getLocation() + " at taxon " + taxonID, ex);
+        }
+    }
+
+    /**
+     * Load ta taxon DwCA into a taxonomy.
+     *
+     * @param taxonomy The taxonomy
+     *
+     * @throws IndexBuilderException if unable to load a record into the taxonomy.
+     */
+    protected void loadTaxonDwCA(Taxonomy taxonomy) throws IndexBuilderException {
+        if (archive.getCore().getRowType() != DwcTerm.Taxon)
+            throw new IndexBuilderException("Expecting a core row type of " + DwcTerm.Taxon);
         List<Term> classifiers = TaxonConceptInstance.CLASSIFICATION_FIELDS.stream().filter(t -> archive.getCore().hasTerm(t)).collect(Collectors.toList());
         taxonomy.addOutputTerms(archive.getCore().getRowType(), archive.getCore().getTerms());
-        if (archive.getCore().getRowType() == DwcTerm.Taxon)
-            taxonomy.addOutputTerms(ALATerm.TaxonVariant, archive.getCore().getTerms());
+        taxonomy.addOutputTerms(ALATerm.TaxonVariant, archive.getCore().getTerms());
         String taxonID = null;
         for (ArchiveFile ext: archive.getExtensions())
             taxonomy.addOutputTerms(ext.getRowType(), ext.getTerms());
@@ -194,8 +252,8 @@ public class DwcaNameSource extends NameSource {
                 String year = core.value(DwcTerm.namePublishedInYear);
                 String verbatimTaxonomicStatus = core.value(DwcTerm.taxonomicStatus);
                 TaxonomicType taxonomicStatus = taxonomy.resolveTaxonomicType(verbatimTaxonomicStatus);
-                String verbatiomTaxonRank = core.value(DwcTerm.taxonRank);
-                RankType rank = taxonomy.resolveRank(verbatiomTaxonRank);
+                String verbatimTaxonRank = core.value(DwcTerm.taxonRank);
+                RankType rank = taxonomy.resolveRank(verbatimTaxonRank);
                 String verbatimNomenclaturalStatus = core.value(DwcTerm.nomenclaturalStatus);
                 Set<NomenclaturalStatus> nomenclaturalStatus = taxonomy.resolveNomenclaturalStatus(verbatimNomenclaturalStatus);
                 String parentNameUsage = core.value(DwcTerm.parentNameUsage);
@@ -214,7 +272,7 @@ public class DwcaNameSource extends NameSource {
                         taxonomicStatus,
                         verbatimTaxonomicStatus,
                         rank,
-                        verbatiomTaxonRank,
+                        verbatimTaxonRank,
                         nomenclaturalStatus,
                         verbatimNomenclaturalStatus,
                         parentNameUsage,
@@ -225,10 +283,10 @@ public class DwcaNameSource extends NameSource {
                 instance = taxonomy.addInstance(instance);
 
                 List<Document> docs = new ArrayList<>();
-                docs.add(this.makeDocument(taxonomy, core, instance.getTaxonID()));
+                docs.add(this.makeDocument(taxonomy, core.rowType(), core, instance.getTaxonID()));
                 for (List<Record> ext: record.extensions().values()) {
                     for (Record er: ext) {
-                        docs.add(makeDocument(taxonomy, er, instance.getTaxonID()));
+                        docs.add(makeDocument(taxonomy, er.rowType(), er, instance.getTaxonID()));
                     }
                 }
                 taxonomy.addRecords(docs);
@@ -243,19 +301,23 @@ public class DwcaNameSource extends NameSource {
      * Convert a record into a lucene document
      *
      * @param taxonomy The target taxonomy
+     * @param type The type of record
      * @param record The record
-     * @param taxonID The actual, stored taxonID
+     * @param taxonID The actual, stored taxonID (used as a link)
      *
      * @return The record as a document
      */
-    private Document makeDocument(Taxonomy taxonomy, Record record, String taxonID) {
+    private Document makeDocument(Taxonomy taxonomy, Term type, Record record, String taxonID) {
         Document doc = new Document();
-        doc.add(new StringField("type", record.rowType().qualifiedName(), Field.Store.YES));
+        doc.add(new StringField("type", type.qualifiedName(), Field.Store.YES));
         doc.add(new StringField("id", UUID.randomUUID().toString(), Field.Store.YES));
+        doc.add(new StringField(Taxonomy.fieldName(DwcTerm.taxonID), taxonID, Field.Store.YES));
         for (Term term: record.terms()) {
-            String value = term == DwcTerm.taxonID ? taxonID : record.value(term);
+            if (term == DwcTerm.taxonID)
+                continue;
+            String value = record.value(term);
             if (term != null && value != null && !value.isEmpty())
-                doc.add(new StringField(taxonomy.fieldName(term), value, Field.Store.YES));
+                doc.add(new StringField(Taxonomy.fieldName(term), value, Field.Store.YES));
         }
         return doc;
     }

--- a/src/main/java/au/org/ala/names/index/Name.java
+++ b/src/main/java/au/org/ala/names/index/Name.java
@@ -2,6 +2,7 @@ package au.org.ala.names.index;
 
 
 import au.org.ala.names.model.RankType;
+import org.gbif.api.vocabulary.NomenclaturalCode;
 
 import java.util.*;
 import java.util.stream.Collectors;

--- a/src/main/java/au/org/ala/names/index/NameAnalyser.java
+++ b/src/main/java/au/org/ala/names/index/NameAnalyser.java
@@ -55,7 +55,7 @@ abstract public class NameAnalyser implements Comparator<NameKey>, Reporter {
      *
      * @return A suitable name key
      */
-    abstract public NameKey analyse(NomenclaturalCode code, String scientificName, @Nullable String scientificNameAuthorship, @Nullable RankType rankType, boolean loose);
+    abstract public NameKey analyse(@Nullable NomenclaturalCode code, String scientificName, @Nullable String scientificNameAuthorship, @Nullable RankType rankType, boolean loose);
 
     /**
      * Set the issue reporter.
@@ -158,4 +158,17 @@ abstract public class NameAnalyser implements Comparator<NameKey>, Reporter {
         else
             logger.warn("Report " + type.name() + " code=" + code + " elements=" + Arrays.toString(elements));
     }
+
+    /**
+     * Compare author strings.
+     * <p>
+     * This usually compared equality across author abbreviations.
+     *
+     * </p>
+     * @param author1 The first author string (may be null)
+     * @param author2 The second author string (may be null)
+     *
+     * @return A value less than, greater than or equal to 0, similar to compare
+     */
+    public abstract int compareAuthor(String author1, String author2);
 }

--- a/src/main/java/au/org/ala/names/index/NameKey.java
+++ b/src/main/java/au/org/ala/names/index/NameKey.java
@@ -99,6 +99,15 @@ public class NameKey implements Comparable<NameKey> {
     }
 
     /**
+     * Is this an unauthored name, meaning that it does not have a scientific name author?
+     *
+     * @return True if the name key is unauthored
+     */
+    public boolean isUnauthored() {
+        return this.scientificNameAuthorship == null;
+    }
+
+    /**
      * Is this an uncoded name, meaning that it does not have a nomenclatural code to accurately
      * distinguish between homonyms?
      *
@@ -206,5 +215,16 @@ public class NameKey implements Comparable<NameKey> {
     @Override
     public int compareTo(NameKey o) {
         return this.analyser.compare(this, o);
+    }
+
+    /**
+     * Compare authorship
+     *
+     * @param author The author to compare with
+     *
+     * @return
+     */
+    public int compareAuthor(String author) {
+        return this.analyser.compareAuthor(this.scientificNameAuthorship, author);
     }
 }

--- a/src/main/java/au/org/ala/names/index/NameSource.java
+++ b/src/main/java/au/org/ala/names/index/NameSource.java
@@ -1,18 +1,15 @@
 package au.org.ala.names.index;
 
 import au.org.ala.vocab.ALATerm;
-import com.google.common.io.Files;
 import org.apache.commons.collections.MapUtils;
 import org.gbif.api.model.registry.Citation;
 import org.gbif.api.model.registry.Contact;
 import org.gbif.api.vocabulary.Country;
 import org.gbif.dwc.terms.*;
 
-import java.io.*;
-import java.nio.charset.Charset;
-import java.nio.file.FileSystem;
-import java.nio.file.FileSystems;
-import java.nio.file.Path;
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.*;
 
 /**
@@ -124,10 +121,23 @@ abstract public class NameSource {
             GbifTerm.isPreferredName,
             GbifTerm.organismPart,
             DwcTerm.taxonRemarks,
+            ALATerm.status,
             DcTerm.source
     );
-    /** Terms not to be included in identifier outputs */
+    /** Terms not to be included in vernacular outputs */
     protected static final List<Term> VERNACULAR_FORBIDDEN = Arrays.asList(
+            DwcTerm.scientificName,
+            DwcTerm.scientificNameAuthorship,
+            DwcTerm.nomenclaturalCode,
+            DwcTerm.taxonRank,
+            DwcTerm.kingdom,
+            DwcTerm.phylum,
+            DwcTerm.class_,
+            DwcTerm.order,
+            DwcTerm.family,
+            DwcTerm.genus,
+            DwcTerm.specificEpithet,
+            DwcTerm.infraspecificEpithet
     );
     /** Fields expected for a speices distribution */
     protected static final List<Term> DISTRIBUTION_REQUIRED = Arrays.asList(
@@ -338,7 +348,7 @@ abstract public class NameSource {
             if (nf.isDirectory())
                 ns = new DwcaNameSource(nf);
             else
-                ns = new CSVNameSource(Files.newReader(nf, Charset.forName("UTF-8")));
+                ns = new CSVNameSource(nf.toPath(), "UTF-8", DwcTerm.Taxon);
             ns.validate();
             return ns;
         } catch (IOException ex) {

--- a/src/main/java/au/org/ala/names/index/TaxonConcept.java
+++ b/src/main/java/au/org/ala/names/index/TaxonConcept.java
@@ -2,6 +2,7 @@ package au.org.ala.names.index;
 
 import au.org.ala.vocab.ALATerm;
 import au.org.ala.names.model.RankType;
+import org.gbif.api.vocabulary.NomenclaturalCode;
 import org.gbif.dwc.terms.DwcTerm;
 import org.gbif.dwc.terms.GbifTerm;
 import org.gbif.dwc.terms.Term;

--- a/src/main/java/au/org/ala/names/index/TaxonomicElement.java
+++ b/src/main/java/au/org/ala/names/index/TaxonomicElement.java
@@ -1,6 +1,7 @@
 package au.org.ala.names.index;
 
 import au.org.ala.names.model.RankType;
+import org.gbif.api.vocabulary.NomenclaturalCode;
 
 import java.util.Comparator;
 

--- a/src/main/java/au/org/ala/names/index/TaxonomyConfiguration.java
+++ b/src/main/java/au/org/ala/names/index/TaxonomyConfiguration.java
@@ -9,9 +9,8 @@ import org.gbif.api.model.registry.Contact;
 
 import java.io.*;
 import java.net.URI;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.UUID;
+import java.util.*;
+import java.util.stream.Collectors;
 
 /**
  * A readable description of a taxonomy construction.
@@ -137,5 +136,23 @@ public class TaxonomyConfiguration {
             sb.append(this.contact.getOrganization());
         }
         return sb.toString().trim();
+    }
+
+    /**
+     * Build a priority list of boosts for the providers and other elements.
+     * <p>
+     * Used whem building name matching indexes.
+     * </p>
+     *
+     * @return The resulting priorities
+     */
+    @JsonIgnore
+    public Properties getPriorities() {
+        int max = this.providers.stream().mapToInt(NameProvider::getDefaultScore).max().orElse(1);
+        double scale = 2.0 / max; // Highest boost is 2
+        Properties properties = new Properties();
+        for (NameProvider p: this.providers)
+            properties.setProperty(p.getId(), Double.toString(Math.max(0.25, p.getDefaultScore() * scale)));
+        return properties;
     }
 }

--- a/src/main/java/au/org/ala/names/search/DwcaNameIndexer.java
+++ b/src/main/java/au/org/ala/names/search/DwcaNameIndexer.java
@@ -380,7 +380,7 @@ public class DwcaNameIndexer extends ALANameIndexer {
      * @param archiveDirectory
      * @throws Exception
      */
-    private boolean createLoadingIndex(File archiveDirectory) throws Exception{
+    public boolean createLoadingIndex(File archiveDirectory) throws Exception{
         if (archiveDirectory == null || !archiveDirectory.exists()) {
             log.warn("Unable to created loading index for " + archiveDirectory + " as it does not exisit");
             return false;
@@ -518,7 +518,7 @@ public class DwcaNameIndexer extends ALANameIndexer {
      *
      * @throws Exception
      */
-    private void generateIndex() throws Exception{
+    public void generateIndex() throws Exception{
         //get all the records that don't have parents that are accepted
         log.info("Loading index from temporary index.");
         TopDocs rootConcepts = getLoadIdxResults(null, "root", "T", PAGE_SIZE);

--- a/src/main/java/au/org/ala/vocab/ALATerm.java
+++ b/src/main/java/au/org/ala/vocab/ALATerm.java
@@ -47,6 +47,8 @@ public enum ALATerm implements Term {
     suborder,
     /** The infraorder classification */
     infraorder,
+    /** Record type describing an unplaced vernacular name */
+    UplacedVernacularName,
     /** Record type describing a variant (different source, spelling etc.) of a taxon */
     TaxonVariant,
     /** Record type describing a problem or note about a taxon */

--- a/src/main/resources/taxonomy.properties
+++ b/src/main/resources/taxonomy.properties
@@ -9,20 +9,22 @@ count.load.INFORMAL=Load has {0} informal names
 count.load.NO_NAME=Load has {0} invalid names
 count.load.PLACEHOLDER=Load has {0} placeholder names
 count.load.SCIENTIFIC=Load has {0} scientific names
-count.load.VIRUS=Load has {0} placeholder names
+count.load.VIRUS=Load has {0} virus names
 count.reallocate.scientificName=Reallocated {0} scientific names
 count.reallocate.taxonConcept=Reallocated {0} taxon concepts
 count.reallocate.uncodedScientificName=Reallocated {0} uncoded scientific names
 count.reallocate.unrankedScientificName=Reallocated {0} unranked scientific names
 count.resolve.inferredSynonym=Created {0} inferred synonyms
 count.resolve.instance.links=Resolved {0} instance links
-count.resolve.scientificName.principal=Resolved {0} principal taxon concepts
-count.resolve.taxonConcept=Resolved {0} taxon concepts
-count.resolve.unrankedScientificName.principal=Resolved {0} principal scientific names
-count.resolve.uncodedScientificName.principal=Resolved {0} principal unranked names
+count.resolve.scientificName.principal=Resolved {0} principal taxon concepts onto scientific names
+count.resolve.taxonConcept=Resolved {0} taxon concepts to principal taxon concepts
+count.resolve.unrankedScientificName.principal=Resolved {0} principal scientific names onto unranked names
+count.resolve.uncodedScientificName.principal=Resolved {0} principal unranked names onto uncoded names
 count.write.report=Written {0} reports
 count.write.scientificName=Written {0} scientific names
 count.write.taxonConcept=Written {0} taxon concepts
+count.vernacularName.placed=Placed {0} additional vernacular names
+count.vernacularName.unplaced=Unable to find taxa for {0} additional vernacular names
 dwca.additionalInfo=Created by combining source taxonomies using the ala-name-matching algorithms. \
   See https://github.com/AtlasOfLivingAustralia/ala-name-matching for more information.
 instance.accepted.resolve=Unable to resolve accepted taxon for {0}: {1} {2}
@@ -86,5 +88,6 @@ uncodedScientificName.reallocated=Uncoded scientific name {0}: {1} reallocated t
 unrankedScientificName.collision=Unranked scientific name {0} collision between scientific names {3}
 unrankedScientificName.collision.match=Unranked scientific name {0} has multiple candidates {3}, choosing first
 unrankedScientificName.reallocated=Unranked scientific name {0}: {1} reallocated to {3}
+vernacularName.unplaced=Unable to find corresponding taxon for {0} with scientific name {1} {2}
 
 

--- a/src/test/java/au/org/ala/names/index/ALANameAnalyserTest.java
+++ b/src/test/java/au/org/ala/names/index/ALANameAnalyserTest.java
@@ -131,6 +131,26 @@ public class ALANameAnalyserTest {
         assertNull(key.getScientificNameAuthorship());
     }
 
+    @Test
+    public void testAuthorEquals1() throws Exception {
+        assertEquals(0, this.analyser.compareAuthor(null, null));
+        assertTrue( this.analyser.compareAuthor("L.", null) > 0);
+        assertTrue(this.analyser.compareAuthor(null, "L.") < 0);
+    }
+
+    @Test
+    public void testAuthorEquals2() throws Exception {
+        assertEquals(0, this.analyser.compareAuthor("Lindel", "Lindel"));
+        assertTrue( this.analyser.compareAuthor("Alphose", "Lindel") < 0);
+        assertTrue(this.analyser.compareAuthor("Lindel", "Alphonse") > 0);
+    }
+
+    @Test
+    public void testAuthorEquals3() throws Exception {
+        assertEquals(0, this.analyser.compareAuthor("L.", "Linnaeus"));
+        assertEquals(0, this.analyser.compareAuthor("L.", "Lin."));
+     }
+
 
     @Test
     public void testKeyEquals1() throws Exception {

--- a/src/test/java/au/org/ala/names/index/ALATaxonResolverTest.java
+++ b/src/test/java/au/org/ala/names/index/ALATaxonResolverTest.java
@@ -1,6 +1,7 @@
 package au.org.ala.names.index;
 
 import au.org.ala.names.util.TestUtils;
+import org.gbif.dwc.terms.DwcTerm;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -23,7 +24,7 @@ public class ALATaxonResolverTest extends TestUtils {
     public void testLub1() throws Exception {
         Taxonomy taxonomy = new Taxonomy();
         taxonomy.begin();
-        CSVNameSource source = new CSVNameSource(this.resourceReader("taxonomy-3.csv"));
+        CSVNameSource source = new CSVNameSource(this.resourceReader("taxonomy-3.csv"), DwcTerm.Taxon);
         taxonomy.load(Arrays.asList(source));
         taxonomy.resolveLinks();
         TaxonConceptInstance i1 = taxonomy.getInstance("http://id.biodiversity.org.au/node/ausmoss/10044711");
@@ -38,7 +39,7 @@ public class ALATaxonResolverTest extends TestUtils {
     public void testLub2() throws Exception {
         Taxonomy taxonomy = new Taxonomy();
         taxonomy.begin();
-        CSVNameSource source = new CSVNameSource(this.resourceReader("taxonomy-3.csv"));
+        CSVNameSource source = new CSVNameSource(this.resourceReader("taxonomy-3.csv"), DwcTerm.Taxon);
         taxonomy.load(Arrays.asList(source));
         taxonomy.resolveLinks();
         TaxonConceptInstance i1 = taxonomy.getInstance("http://id.biodiversity.org.au/node/ausmoss/10044715");
@@ -53,7 +54,7 @@ public class ALATaxonResolverTest extends TestUtils {
     public void testLub3() throws Exception {
         Taxonomy taxonomy = new Taxonomy();
         taxonomy.begin();
-        CSVNameSource source = new CSVNameSource(this.resourceReader("taxonomy-3.csv"));
+        CSVNameSource source = new CSVNameSource(this.resourceReader("taxonomy-3.csv"), DwcTerm.Taxon);
         taxonomy.load(Arrays.asList(source));
         taxonomy.resolveLinks();
         TaxonConceptInstance i1 = taxonomy.getInstance("http://id.biodiversity.org.au/node/ausmoss/10044711");
@@ -68,7 +69,7 @@ public class ALATaxonResolverTest extends TestUtils {
     public void testLub4() throws Exception {
         Taxonomy taxonomy = new Taxonomy();
         taxonomy.begin();
-        CSVNameSource source = new CSVNameSource(this.resourceReader("taxonomy-3.csv"));
+        CSVNameSource source = new CSVNameSource(this.resourceReader("taxonomy-3.csv"), DwcTerm.Taxon);
         taxonomy.load(Arrays.asList(source));
         taxonomy.resolveLinks();
         TaxonConceptInstance i1 = taxonomy.getInstance("http://id.biodiversity.org.au/node/ausmoss/10044711");

--- a/src/test/java/au/org/ala/names/index/CSVNameSourceTest.java
+++ b/src/test/java/au/org/ala/names/index/CSVNameSourceTest.java
@@ -39,14 +39,14 @@ public class CSVNameSourceTest extends TestUtils {
 
     @Test
     public void testValidate1() throws Exception {
-        CSVNameSource source = new CSVNameSource(this.resourceReader("taxonomy-1.csv"));
+        CSVNameSource source = new CSVNameSource(this.resourceReader("taxonomy-1.csv"), DwcTerm.Taxon);
         source.validate();
     }
 
     @Test
     public void testValidate2() throws Exception {
         try {
-            CSVNameSource source = new CSVNameSource(this.resourceReader("taxonomy-bad-1.csv"));
+            CSVNameSource source = new CSVNameSource(this.resourceReader("taxonomy-bad-1.csv"), DwcTerm.Taxon);
             source.validate();
             fail("Expected IndexBuilderException");
         } catch (IndexBuilderException ex) {
@@ -55,7 +55,7 @@ public class CSVNameSourceTest extends TestUtils {
 
     @Test
     public void testLoadIntoTaxonomy1() throws Exception {
-        CSVNameSource source = new CSVNameSource(this.resourceReader("taxonomy-1.csv"));
+        CSVNameSource source = new CSVNameSource(this.resourceReader("taxonomy-1.csv"), DwcTerm.Taxon);
         this.taxonomy.load(Arrays.asList(source));
         TaxonConceptInstance instance = this.taxonomy.getInstance("http://id.biodiversity.org.au/node/ausmoss/10044710");
         assertNotNull(instance);
@@ -85,7 +85,7 @@ public class CSVNameSourceTest extends TestUtils {
 
     @Test
     public void testLoadIntoTaxonomy2() throws Exception {
-        CSVNameSource source = new CSVNameSource(this.resourceReader("taxonomy-2.csv"));
+        CSVNameSource source = new CSVNameSource(this.resourceReader("taxonomy-2.csv"), DwcTerm.Taxon);
         this.taxonomy.load(Arrays.asList(source));
         TaxonConceptInstance instance = this.taxonomy.getInstance("http://id.biodiversity.org.au/node/ausmoss/10044710");
         assertNotNull(instance);

--- a/src/test/java/au/org/ala/names/index/TaxonomyConfiugrationTest.java
+++ b/src/test/java/au/org/ala/names/index/TaxonomyConfiugrationTest.java
@@ -8,6 +8,7 @@ import org.junit.Test;
 
 import java.io.StringWriter;
 import java.util.Arrays;
+import java.util.Properties;
 
 import static org.junit.Assert.*;
 
@@ -125,5 +126,17 @@ public class TaxonomyConfiugrationTest extends TestUtils {
         assertEquals(CLN, config.contact.getLastName());
         assertEquals(COR, config.contact.getOrganization());
     }
+
+    @Test
+    public void testPriorities1() throws Exception {
+        TaxonomyConfiguration config = TaxonomyConfiguration.read(this.resourceReader("taxonomy-config-2.json"));
+        Properties properties = config.getPriorities();
+        assertNotNull(properties.getProperty("dr100"));
+        assertEquals(2.0, Double.parseDouble(properties.getProperty("dr100")), 0.01);
+        assertNotNull(properties.getProperty("dr100"));
+        assertEquals(2.0 * 125 / 150, Double.parseDouble(properties.getProperty("dr101")), 0.01);
+        assertNull(properties.getProperty("dr102"));
+    }
+
 
 }

--- a/src/test/java/au/org/ala/names/index/TaxonomyTest.java
+++ b/src/test/java/au/org/ala/names/index/TaxonomyTest.java
@@ -1,6 +1,8 @@
 package au.org.ala.names.index;
 
 import au.org.ala.names.util.TestUtils;
+import org.gbif.dwc.terms.DwcTerm;
+import org.gbif.dwc.terms.GbifTerm;
 import org.junit.After;
 import org.junit.Test;
 
@@ -30,7 +32,7 @@ public class TaxonomyTest extends TestUtils {
     public void testResolveLinks1() throws Exception {
         this.taxonomy = new Taxonomy();
         this.taxonomy.begin();
-        CSVNameSource source = new CSVNameSource(this.resourceReader("taxonomy-1.csv"));
+        CSVNameSource source = new CSVNameSource(this.resourceReader("taxonomy-1.csv"), DwcTerm.Taxon);
         this.taxonomy.load(Arrays.asList(source));
         this.taxonomy.resolveLinks();
         TaxonConceptInstance i1 = this.taxonomy.getInstance("http://id.biodiversity.org.au/node/ausmoss/10044710");
@@ -53,7 +55,7 @@ public class TaxonomyTest extends TestUtils {
     public void testResolveLinks2() throws Exception {
         this.taxonomy = new Taxonomy();
         this.taxonomy.begin();
-        CSVNameSource source = new CSVNameSource(this.resourceReader("taxonomy-2.csv"));
+        CSVNameSource source = new CSVNameSource(this.resourceReader("taxonomy-2.csv"), DwcTerm.Taxon);
         this.taxonomy.load(Arrays.asList(source));
         this.taxonomy.resolveLinks();
         TaxonConceptInstance i1 = this.taxonomy.getInstance("http://id.biodiversity.org.au/node/ausmoss/10044710");
@@ -74,7 +76,7 @@ public class TaxonomyTest extends TestUtils {
     public void testResolveTaxon1() throws Exception {
         this.taxonomy = new Taxonomy();
         this.taxonomy.begin();
-        CSVNameSource source = new CSVNameSource(this.resourceReader("taxonomy-1.csv"));
+        CSVNameSource source = new CSVNameSource(this.resourceReader("taxonomy-1.csv"), DwcTerm.Taxon);
         this.taxonomy.load(Arrays.asList(source));
         this.taxonomy.resolveLinks();
         this.taxonomy.resolveTaxon();
@@ -95,8 +97,8 @@ public class TaxonomyTest extends TestUtils {
         TaxonomyConfiguration config = TaxonomyConfiguration.read(this.resourceReader("taxonomy-config-2.json"));
         this.taxonomy = new Taxonomy(config, null);
         this.taxonomy.begin();
-        CSVNameSource source1 = new CSVNameSource(this.resourceReader("taxonomy-3.csv"));
-        CSVNameSource source2 = new CSVNameSource(this.resourceReader("taxonomy-4.csv"));
+        CSVNameSource source1 = new CSVNameSource(this.resourceReader("taxonomy-3.csv"), DwcTerm.Taxon);
+        CSVNameSource source2 = new CSVNameSource(this.resourceReader("taxonomy-4.csv"), DwcTerm.Taxon);
         this.taxonomy.load(Arrays.asList(source1, source2));
         this.taxonomy.resolveLinks();
         this.taxonomy.resolveTaxon();
@@ -129,8 +131,8 @@ public class TaxonomyTest extends TestUtils {
         TaxonomyConfiguration config = TaxonomyConfiguration.read(this.resourceReader("taxonomy-config-2.json"));
         this.taxonomy = new Taxonomy(config, null);
         this.taxonomy.begin();
-        CSVNameSource source1 = new CSVNameSource(this.resourceReader("taxonomy-3.csv"));
-        CSVNameSource source2 = new CSVNameSource(this.resourceReader("taxonomy-5.csv"));
+        CSVNameSource source1 = new CSVNameSource(this.resourceReader("taxonomy-3.csv"), DwcTerm.Taxon);
+        CSVNameSource source2 = new CSVNameSource(this.resourceReader("taxonomy-5.csv"), DwcTerm.Taxon);
         this.taxonomy.load(Arrays.asList(source1, source2));
         this.taxonomy.resolveLinks();
         this.taxonomy.resolveTaxon();
@@ -163,7 +165,7 @@ public class TaxonomyTest extends TestUtils {
         TaxonomyConfiguration config = TaxonomyConfiguration.read(this.resourceReader("taxonomy-config-2.json"));
         this.taxonomy = new Taxonomy(config, null);
         this.taxonomy.begin();
-        CSVNameSource source1 = new CSVNameSource(this.resourceReader("taxonomy-7.csv"));
+        CSVNameSource source1 = new CSVNameSource(this.resourceReader("taxonomy-7.csv"), DwcTerm.Taxon);
         this.taxonomy.load(Arrays.asList(source1));
         this.taxonomy.resolve();
         TaxonConceptInstance i11 = this.taxonomy.getInstance("NZOR-4-28207");
@@ -198,7 +200,7 @@ public class TaxonomyTest extends TestUtils {
         TaxonomyConfiguration config = TaxonomyConfiguration.read(this.resourceReader("taxonomy-config-2.json"));
         this.taxonomy = new Taxonomy(config, null);
         this.taxonomy.begin();
-        CSVNameSource source1 = new CSVNameSource(this.resourceReader("taxonomy-9.csv"));
+        CSVNameSource source1 = new CSVNameSource(this.resourceReader("taxonomy-9.csv"), DwcTerm.Taxon);
         this.taxonomy.load(Arrays.asList(source1));
         this.taxonomy.resolve();
         TaxonConceptInstance i11 = this.taxonomy.getInstance("NZOR-4-10536");
@@ -226,7 +228,7 @@ public class TaxonomyTest extends TestUtils {
         TaxonomyConfiguration config = TaxonomyConfiguration.read(this.resourceReader("taxonomy-config-2.json"));
         this.taxonomy = new Taxonomy(config, null);
         this.taxonomy.begin();
-        CSVNameSource source1 = new CSVNameSource(this.resourceReader("taxonomy-10.csv"));
+        CSVNameSource source1 = new CSVNameSource(this.resourceReader("taxonomy-10.csv"), DwcTerm.Taxon);
         this.taxonomy.load(Arrays.asList(source1));
         this.taxonomy.resolve();
         TaxonConceptInstance i0 = this.taxonomy.getInstance("http://id.biodiversity.org.au/node/apni/7178434");
@@ -258,7 +260,7 @@ public class TaxonomyTest extends TestUtils {
         TaxonomyConfiguration config = TaxonomyConfiguration.read(this.resourceReader("taxonomy-config-2.json"));
         this.taxonomy = new Taxonomy(config, null);
         this.taxonomy.begin();
-        CSVNameSource source1 = new CSVNameSource(this.resourceReader("taxonomy-8.csv"));
+        CSVNameSource source1 = new CSVNameSource(this.resourceReader("taxonomy-8.csv"), DwcTerm.Taxon);
         this.taxonomy.load(Arrays.asList(source1));
         this.taxonomy.resolve();
         TaxonConceptInstance i11 = this.taxonomy.getInstance("NZOR-4-118018");
@@ -287,8 +289,8 @@ public class TaxonomyTest extends TestUtils {
         TaxonomyConfiguration config = TaxonomyConfiguration.read(this.resourceReader("taxonomy-config-2.json"));
         this.taxonomy = new Taxonomy(config, null);
         this.taxonomy.begin();
-        CSVNameSource source1 = new CSVNameSource(this.resourceReader("taxonomy-3.csv"));
-        CSVNameSource source2 = new CSVNameSource(this.resourceReader("taxonomy-4.csv"));
+        CSVNameSource source1 = new CSVNameSource(this.resourceReader("taxonomy-3.csv"), DwcTerm.Taxon);
+        CSVNameSource source2 = new CSVNameSource(this.resourceReader("taxonomy-4.csv"), DwcTerm.Taxon);
         this.taxonomy.load(Arrays.asList(source1, source2));
         this.taxonomy.resolve();
         File dir = new File(this.taxonomy.getWork(), "output");
@@ -296,10 +298,10 @@ public class TaxonomyTest extends TestUtils {
         this.taxonomy.createDwCA(dir);
         assertTrue(new File(dir, "meta.xml").exists());
         assertTrue(new File(dir, "eml.xml").exists());
-        assertTrue(new File(dir, "taxon.txt").exists());
-        assertTrue(new File(dir, "taxonvariant.txt").exists());
-        assertTrue(new File(dir, "identifier.txt").exists());
-        assertTrue(new File(dir, "rightsholder.txt").exists());
+        assertEquals(11, this.rowCount(new File(dir, "taxon.txt")));
+        assertEquals(21, this.rowCount(new File(dir, "taxonvariant.txt")));
+        assertEquals(51, this.rowCount(new File(dir, "identifier.txt")));
+        assertEquals(4, this.rowCount(new File(dir, "rightsholder.txt")));
 
     }
 
@@ -309,7 +311,7 @@ public class TaxonomyTest extends TestUtils {
         TaxonomyConfiguration config = TaxonomyConfiguration.read(this.resourceReader("taxonomy-config-2.json"));
         this.taxonomy = new Taxonomy(config, null);
         this.taxonomy.begin();
-        CSVNameSource source1 = new CSVNameSource(this.resourceReader("taxonomy-10.csv"));
+        CSVNameSource source1 = new CSVNameSource(this.resourceReader("taxonomy-10.csv"), DwcTerm.Taxon);
         this.taxonomy.load(Arrays.asList(source1));
         this.taxonomy.resolve();
         File dir = new File(this.taxonomy.getWork(), "output");
@@ -317,11 +319,31 @@ public class TaxonomyTest extends TestUtils {
         this.taxonomy.createDwCA(dir);
         assertTrue(new File(dir, "meta.xml").exists());
         assertTrue(new File(dir, "eml.xml").exists());
-        assertTrue(new File(dir, "taxon.txt").exists());
-        assertTrue(new File(dir, "taxonvariant.txt").exists());
-        assertTrue(new File(dir, "identifier.txt").exists());
-        assertTrue(new File(dir, "rightsholder.txt").exists());
+        assertEquals(4, this.rowCount(new File(dir, "taxon.txt")));
+        assertEquals(5, this.rowCount(new File(dir, "taxonvariant.txt")));
+        assertEquals(5, this.rowCount(new File(dir, "identifier.txt")));
+        assertEquals(5, this.rowCount(new File(dir, "rightsholder.txt")));
+    }
 
+
+    @Test
+    public void testResolveUnplacedVernacular1() throws Exception {
+        TaxonomyConfiguration config = TaxonomyConfiguration.read(this.resourceReader("taxonomy-config-2.json"));
+        this.taxonomy = new Taxonomy(config, null);
+        this.taxonomy.begin();
+        CSVNameSource source1 = new CSVNameSource(this.resourceReader("taxonomy-5.csv"), DwcTerm.Taxon);
+        CSVNameSource source2 = new CSVNameSource(this.resourceReader("vernacular-1.csv"), GbifTerm.VernacularName);
+        this.taxonomy.load(Arrays.asList(source1, source2));
+        this.taxonomy.resolve();
+        this.taxonomy.createWorkingIndex();
+        this.taxonomy.resolveUnplacedVernacular();
+        File dir = new File(this.taxonomy.getWork(), "output");
+        dir.mkdir();
+        this.taxonomy.createDwCA(dir);
+        assertTrue(new File(dir, "meta.xml").exists());
+        assertTrue(new File(dir, "eml.xml").exists());
+        assertEquals(11, this.rowCount(new File(dir, "taxon.txt")));
+        assertEquals(2, this.rowCount(new File(dir, "vernacularname.txt")));
     }
 
 }

--- a/src/test/java/au/org/ala/names/util/TestUtils.java
+++ b/src/test/java/au/org/ala/names/util/TestUtils.java
@@ -49,4 +49,11 @@ public class TestUtils {
         return new TaxonConceptInstance(id, code, code.getAcronym(), provider, name, null, null, taxonomicStatus, taxonomicStatus.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null);
     }
 
+    public int rowCount(File file) throws IOException {
+        if (!file.exists())
+            return -1;
+        BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream(file), "UTF-8"));
+        return (int) reader.lines().count();
+    }
+
 }

--- a/src/test/resources/au/org/ala/names/index/vernacular-1.csv
+++ b/src/test/resources/au/org/ala/names/index/vernacular-1.csv
@@ -1,0 +1,2 @@
+scientificName,vernacularName
+Sematophyllaceae,Amusing Moss


### PR DESCRIPTION
Allow vernacular names keyed by just scientific name and, possibly, higher taxonomy to be included in the taxonomy merger. (The Large Taxon Collider)

This allows lists of vernacular names from the ALA list server to be included.