### PR TITLE
Handle miscellaneous literature names as vernacular names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,10 @@ branches:
   
 before_install:
 - mkdir -p ~/.m2; wget -q -O ~/.m2/settings.xml https://raw.githubusercontent.com/AtlasOfLivingAustralia/travis-build-configuration/master/travis_maven_settings_simple.xml
-- sudo mkdir -p /data/lucene; sudo wget -O /data/lucene/namematching-20170927.tgz http://biocache.ala.org.au/archives/nameindexes/20170927/namematching-20170927.tgz
+- sudo mkdir -p /data/lucene; sudo wget -O /data/lucene/namematching-20181105.tgz http://archives.ala.org.au/archives/nameindexes/20181105/namematching-20181105.tgz
 - cd /data/lucene
-- sudo tar zxvf namematching-20170927.tgz
-- sudo ln -s namematching-20170927 namematching
+- sudo tar zxvf namematching-20181105.tgz
+- sudo ln -s namematching-20181105 namematching
 - ls -laF
 - cd $TRAVIS_BUILD_DIR
 

--- a/README.md
+++ b/README.md
@@ -83,8 +83,8 @@ The build creates 3 artefacts in the ala-name-matching/target directory:
 * ala-name-matching-2.4.6-distribution.zip - zip containing the project jar and dependencies
 * ala-name-matching-2.4.6-sources.jar - source jar for the project code only
 
-The name index for Australian names lists used in unit tests can be downloaded [from here](http://biocache.ala.org.au/archives/nameindexes/20170927) and needs to be extracted to the
-directory `/data/lucene/namematching-20170927`
+The name index for Australian names lists used in unit tests can be downloaded [from here](http://biocache.ala.org.au/archives/nameindexes/20181105) and needs to be extracted to the
+directory `/data/lucene/namematching-20181105`
 
 ## ALA Names List
 

--- a/data/ala-taxon-config.json
+++ b/data/ala-taxon-config.json
@@ -21,10 +21,6 @@
         "forbidden": [
           {
             "@class": "au.org.ala.names.index.provider.MatchTaxonCondition",
-            "taxonomicStatus": "INCERTAE_SEDIS"
-          },
-          {
-            "@class": "au.org.ala.names.index.provider.MatchTaxonCondition",
             "taxonomicStatus": "INVALID"
           },
           {
@@ -50,9 +46,23 @@
           {
             "condition": {
               "@class": "au.org.ala.names.index.provider.MatchTaxonCondition",
-              "taxonomicStatus": "MISCELLANEOUS_LITERATURE"
+              "taxonomicStatus": "INCERTAE_SEDIS"
             },
             "adjustment": -200
+          },
+          {
+            "condition": {
+              "@class": "au.org.ala.names.index.provider.MatchTaxonCondition",
+              "taxonomicStatus": "SPECIES_INQUIRENDA"
+            },
+            "adjustment": -200
+          },
+          {
+            "condition": {
+              "@class": "au.org.ala.names.index.provider.MatchTaxonCondition",
+              "taxonomicStatus": "MISCELLANEOUS_LITERATURE"
+            },
+            "adjustment": -250
           },
           {
             "condition": {

--- a/data/ala-taxon-config.json
+++ b/data/ala-taxon-config.json
@@ -714,7 +714,8 @@
       "rightsHolder": "Atlas of Living Australia",
       "licence": "CC-BY",
       "parent": "default",
-      "defaultScore" : 0
+      "defaultScore" : 0,
+      "unrankedStrategy": "INFERRED_AND_SYNONYMS"
     }
   ],
   "defaultProvider" : "dr5393",

--- a/data/ala-taxon-config.json
+++ b/data/ala-taxon-config.json
@@ -1,7 +1,7 @@
 {
   "id": "ALA-Combined",
   "name": "ALA Combined Taxonomy",
-  "description": "Resolved taxonomy built from AusFungi, AusMoss, AFD, APNI/APC, NZOR, CCAB, Catalogue of Life and ALA speices lists",
+  "description": "Resolved taxonomy built from AusFungi, AusMoss, AFD, APNI/APC, NZOR, CAAB, Catalogue of Life and ALA species lists",
   "contact": {
     "organization": "Atlas of Living Australia",
     "email": [ "data_management@ala.org.au" ]

--- a/doc/merge-config.md
+++ b/doc/merge-config.md
@@ -75,12 +75,11 @@ Each provider contains the following information:
   SYNONYMISE_TO_PARENT makes the discarded taxon a synonym of its parent (use this option with caution, since
   you are likely to get a large number of "Unplaced"s acting as synonyms).
 * **unrankedStrategy** How to handle unranked taxa. This can be one of
-  NONE (the default) which simply leaves unranked taxa as-is, SYNONYMS which searches for a ranked taxon
-  with the same name/author for synonyms only or ALL which searches for a ranked taxon for all unranked
-  taxa.
+  `NONE` (the default) which simply leaves unranked taxa as-is, `SYNONYMS` which searches for an existing ranked taxon
+  with the same name/author for synonyms only or `ALL` which searches for an existing ranked taxon for all unranked
+  taxa. If you use `SYNONYMS_INFER` or `ALL_INFER` an attempt to infer the rank is made, even if there isn't an existing ranked taxon.
 * **unknownTaxonID** An identifier for a missing taxon. Synonym loops and the like map onto this
-  taxon, which must exist in the taxonomy.
-
+  taxon. If the taxon doesn't already exist, it is created.
 
 
 ### Adjusters

--- a/doc/merge-config.md
+++ b/doc/merge-config.md
@@ -76,8 +76,10 @@ Each provider contains the following information:
   you are likely to get a large number of "Unplaced"s acting as synonyms).
 * **unrankedStrategy** How to handle unranked taxa. This can be one of
   `NONE` (the default) which simply leaves unranked taxa as-is, `SYNONYMS` which searches for an existing ranked taxon
-  with the same name/author for synonyms only or `ALL` which searches for an existing ranked taxon for all unranked
-  taxa. If you use `SYNONYMS_INFER` or `ALL_INFER` an attempt to infer the rank is made, even if there isn't an existing ranked taxon.
+  with the same name/author for synonyms only, `INFERRED_AND_SYNONYMS` which searches for inferred status taxa or synonyms
+   or `ALL` which searches for an existing ranked taxon for all unranked
+  taxa. If you use `SYNONYMS_INFER`, `INFERRED_AND_SYNONYMS_INFER` or `ALL_INFER` an attempt to infer the rank is made, 
+  even if there isn't an existing ranked taxon.
 * **unknownTaxonID** An identifier for a missing taxon. Synonym loops and the like map onto this
   taxon. If the taxon doesn't already exist, it is created.
 

--- a/src/main/java/au/org/ala/names/index/ALANameAnalyser.java
+++ b/src/main/java/au/org/ala/names/index/ALANameAnalyser.java
@@ -163,8 +163,6 @@ public class ALANameAnalyser extends NameAnalyser {
             ParsedName name = null;
             try {
                 name = this.nameParser.parse(scientificName, (rankType == null || rankType == RankType.UNRANKED) ? null : rankType.getCbRank());
-                if ((rankType == null || rankType == RankType.UNRANKED) && name.getRank() != null)
-                    rankType = RankType.getForCBRank(name.getRank());
             } catch (UnparsableException ex) {
                 // Oh well, worth a try
             }

--- a/src/main/java/au/org/ala/names/index/ALANameAnalyser.java
+++ b/src/main/java/au/org/ala/names/index/ALANameAnalyser.java
@@ -215,11 +215,6 @@ public class ALANameAnalyser extends NameAnalyser {
         if (rankType == null)
             rankType = RankType.UNRANKED;
 
-        // Loose name clean up
-        if (loose) {
-            scientificName = DOUBTFUL.matcher(scientificName).replaceAll(" ");
-        }
-
         // Remove non-name characters
         scientificName = NON_NAME.matcher(scientificName).replaceAll(" ");
         scientificName = SPACES.matcher(scientificName).replaceAll(" ");

--- a/src/main/java/au/org/ala/names/index/ALANameAnalyser.java
+++ b/src/main/java/au/org/ala/names/index/ALANameAnalyser.java
@@ -94,7 +94,7 @@ public class ALANameAnalyser extends NameAnalyser {
     /**
      * Something that looks like an unplaced name
      */
-    protected static final Predicate<String> PLACEHOLDER_TEST = Pattern.compile("(?i:incertae sedis|unplaced)").asPredicate();
+    protected static final Predicate<String> PLACEHOLDER_TEST = Pattern.compile("(?i:species inquirenda|incertae sedis|unplaced)").asPredicate();
     /**
      * Something that looks like a hybrid
      */
@@ -148,12 +148,13 @@ public class ALANameAnalyser extends NameAnalyser {
      * @param scientificName           The scientific name
      * @param scientificNameAuthorship The authorship
      * @param rankType                 The taxon rank
+     * @param taxonomicStatus          The taxonomic status
      * @param loose                    This is from a loose source that may have authors mixed up with names
      *
      * @return The analyzed name
      */
     @Override
-    public NameKey analyse(@Nullable NomenclaturalCode code, String scientificName, @Nullable String scientificNameAuthorship, RankType rankType, boolean loose) {
+    public NameKey analyse(@Nullable NomenclaturalCode code, String scientificName, @Nullable String scientificNameAuthorship, RankType rankType, TaxonomicType taxonomicStatus, boolean loose) {
         NameType nameType = NameType.INFORMAL;
         if (scientificNameAuthorship != null && scientificName.endsWith(scientificNameAuthorship)) {
             scientificName = scientificName.substring(0, scientificName.length() - scientificNameAuthorship.length()).trim();
@@ -186,7 +187,7 @@ public class ALANameAnalyser extends NameAnalyser {
 
 
         // Categorize
-        if (PLACEHOLDER_TEST.test(scientificName)) {
+        if (PLACEHOLDER_TEST.test(scientificName) || (taxonomicStatus != null && taxonomicStatus.isPlaceholder())) {
             scientificName = scientificName + " " + UUID.randomUUID().toString();
             nameType = NameType.PLACEHOLDER;
         } else if (code == NomenclaturalCode.VIRUS) {

--- a/src/main/java/au/org/ala/names/index/ALATaxonResolver.java
+++ b/src/main/java/au/org/ala/names/index/ALATaxonResolver.java
@@ -105,6 +105,12 @@ public class ALATaxonResolver implements TaxonResolver {
      *         <li>If there is a principal taxon matching the same scientific name with the same status, then choose that one</li>
      *         <li>Otherwise, add this as a non-principal</li>
      *     </ol>
+     *     <li>For unplaced or placeholder taxa wihout an accepted taxon
+     *     <ol>
+     *         <li>If there is a principal taxon matching the same taxon concept, then choose that one</li>
+     *         <li>If there is a principal taxon matching the same scientific name, then choose that one</li>
+     *         <li>Otherwise, add this as a non-principal</li>
+     *     </ol>
      *     <li>For non-accepted, non-synonym taxa without an accepted taxon
      *     <ol>
      *         <li>If there is a principal taxon with the same status, then choose that one</li>
@@ -196,6 +202,17 @@ public class ALATaxonResolver implements TaxonResolver {
                 return;
             }
             if ((resolved = resolution.getUsed().stream().filter(tci -> tci.getTaxonomicStatus() == taxonomicStatus && tci.getAccepted() != null && tci.getAccepted().getContainer().getContainer() == acceptedScientificName).findFirst()).isPresent()) {
+                resolution.addInternal(instance, resolved.get(), this.taxonomy);
+                return;
+            }
+            resolution.addInternal(instance, instance, taxonomy);
+            return;
+        } else if (taxonomicStatus.isPlaceholder() || taxonomicStatus.isUnplaced()) {
+            if ((resolved = resolution.getUsed().stream().filter(tci -> tci.getContainer() == taxonConcept).findFirst()).isPresent()) {
+                resolution.addInternal(instance, resolved.get(), this.taxonomy);
+                return;
+            }
+            if ((resolved = resolution.getUsed().stream().filter(tci -> tci.getContainer().getContainer() == acceptedScientificName).findFirst()).isPresent()) {
                 resolution.addInternal(instance, resolved.get(), this.taxonomy);
                 return;
             }

--- a/src/main/java/au/org/ala/names/index/ALATaxonResolver.java
+++ b/src/main/java/au/org/ala/names/index/ALATaxonResolver.java
@@ -232,7 +232,7 @@ public class ALATaxonResolver implements TaxonResolver {
         TaxonConcept found = parent.findRankedConcept(instance.getContainer().getKey(), acceptedRank, this.taxonomy);
         if (found != null) {
             return found.getRank();
-        } else {
+        } else if (instance.getProvider().getUnrankedStrategy().isInferRank()) {
             // Try name analysis to see whether we can get anywhere
             try {
                 NameParser parser = new PhraseNameParser();
@@ -241,8 +241,9 @@ public class ALATaxonResolver implements TaxonResolver {
                     return RankType.getForCBRank(pn.getRank());
             } catch (UnparsableException ex) {
             }
+            return acceptedRank;
         }
-        return acceptedRank;
+        return null;
     }
 
     /**

--- a/src/main/java/au/org/ala/names/index/NameAnalyser.java
+++ b/src/main/java/au/org/ala/names/index/NameAnalyser.java
@@ -36,7 +36,7 @@ abstract public class NameAnalyser implements Comparator<NameKey>, Reporter {
      * Convienience method for testing.
      */
     public NameKey analyse(TaxonConceptInstance instance) {
-        return this.analyse(instance.getCode(), instance.getScientificName(), instance.getScientificNameAuthorship(), instance.getRank(), false);
+        return this.analyse(instance.getCode(), instance.getScientificName(), instance.getScientificNameAuthorship(), instance.getRank(), instance.getTaxonomicStatus(), false);
     }
 
     /**
@@ -45,7 +45,7 @@ abstract public class NameAnalyser implements Comparator<NameKey>, Reporter {
     public NameKey analyse(String code, String scientificName, String scientificNameAuthorship, String rank) {
         NomenclaturalCode canonicalCode = this.canonicaliseCode(code);
         RankType rankType = this.canonicaliseRank(rank);
-        return this.analyse(canonicalCode, scientificName, scientificNameAuthorship, rankType, false);
+        return this.analyse(canonicalCode, scientificName, scientificNameAuthorship, rankType, null, false);
     }
 
     /**
@@ -59,11 +59,12 @@ abstract public class NameAnalyser implements Comparator<NameKey>, Reporter {
      * @param scientificName The scientific name
      * @param scientificNameAuthorship The authorship
      * @param rankType The taxon rank
+     * @param taxonomicStatus The taxonomic status
      * @param loose This is from a loose source that may have names and authors mixed up and the like
      *
      * @return A suitable name key
      */
-    abstract public NameKey analyse(@Nullable NomenclaturalCode code, String scientificName, @Nullable String scientificNameAuthorship, @Nullable RankType rankType, boolean loose);
+    abstract public NameKey analyse(@Nullable NomenclaturalCode code, String scientificName, @Nullable String scientificNameAuthorship, @Nullable RankType rankType, @Nullable TaxonomicType taxonomicStatus, boolean loose);
 
     /**
      * Set the issue reporter.

--- a/src/main/java/au/org/ala/names/index/TaxonConcept.java
+++ b/src/main/java/au/org/ala/names/index/TaxonConcept.java
@@ -192,7 +192,7 @@ public class TaxonConcept extends TaxonomicElement<TaxonConcept, ScientificName>
      */
     public void write(Taxonomy taxonomy, DwcaWriter writer) throws IOException {
         for (TaxonConceptInstance tci : this.resolution.getUsed()) {
-            if (tci.isForbidden()) {
+            if (!tci.isOutput()) {
                 continue;
             }
             Collection<TaxonConceptInstance> allocated = this.resolution.getChildren(tci);
@@ -205,7 +205,7 @@ public class TaxonConcept extends TaxonomicElement<TaxonConcept, ScientificName>
                     if (term != DwcTerm.taxonID) // Already added as coreId
                         writer.addCoreColumn(term, values.get(term));
                 for (TaxonConceptInstance sub : allocated) {
-                    if (sub.isForbidden())
+                    if (!sub.isOutput())
                         continue;
                     this.writeExtension(ALATerm.TaxonVariant, sub == tci ? values : sub.getTaxonMap(taxonomy), taxonomy, writer);
                     taxonomy.count("count.write.taxonConceptInstance");

--- a/src/main/java/au/org/ala/names/index/TaxonConceptInstance.java
+++ b/src/main/java/au/org/ala/names/index/TaxonConceptInstance.java
@@ -614,6 +614,15 @@ public class TaxonConceptInstance extends TaxonomicElement<TaxonConceptInstance,
     }
 
     /**
+     * Should we output this instance?
+     *
+     * @return True if not forbidden and of outputtable taxonomic status
+     */
+    public boolean isOutput() {
+        return !this.isForbidden() && this.getTaxonomicStatus().isOutput();
+    }
+
+    /**
      * Get the classification of the taxon in terms of higher-level taxa.
      *
      * @return

--- a/src/main/java/au/org/ala/names/index/TaxonConceptInstance.java
+++ b/src/main/java/au/org/ala/names/index/TaxonConceptInstance.java
@@ -221,9 +221,9 @@ public class TaxonConceptInstance extends TaxonomicElement<TaxonConceptInstance,
         this.parentNameUsageID = parentNameUsageID;
         this.acceptedNameUsage = acceptedNameUsage;
         this.acceptedNameUsageID = acceptedNameUsageID;
-        this.taxonRemarks = taxonRemarks;
+        this.taxonRemarks = taxonRemarks == null ? null : new ArrayList<>(taxonRemarks);
         this.verbatimTaxonRemarks = verbatimTaxonRemarks;
-        this.provenance = provenance;
+        this.provenance = provenance == null ? null : new ArrayList<>(provenance);
         this.classification = classification;
     }
 

--- a/src/main/java/au/org/ala/names/index/TaxonConceptInstance.java
+++ b/src/main/java/au/org/ala/names/index/TaxonConceptInstance.java
@@ -1359,7 +1359,7 @@ public class TaxonConceptInstance extends TaxonomicElement<TaxonConceptInstance,
         instance.score = null;
         instance.forbidden = false;
         String provenance = taxonomy.getResources().getString("taxonConcept.unranked.reallocate.provenance");
-        provenance = MessageFormat.format(provenance, newRank);
+        provenance = MessageFormat.format(provenance, newRank.getRank());
         instance.addProvenance(provenance);
         taxonomy.report(IssueType.NOTE, "taxonConcept.unranked.reallocate", this, Arrays.asList(instance));
         taxonomy.count("count.resolve.unrankedTaxonConcept");

--- a/src/main/java/au/org/ala/names/index/Taxonomy.java
+++ b/src/main/java/au/org/ala/names/index/Taxonomy.java
@@ -872,7 +872,7 @@ public class Taxonomy implements Reporter {
         NameKey taxonKey;
         String remark, explain;
 
-        taxonKey = this.analyser.analyse(instance.getCode(), instance.getScientificName(), instance.getScientificNameAuthorship(), instance.getRank(), loose);
+        taxonKey = this.analyser.analyse(instance.getCode(), instance.getScientificName(), instance.getScientificNameAuthorship(), instance.getRank(), instance.getTaxonomicStatus(), loose);
         taxonKey = instance.getProvider().adjustKey(taxonKey, instance);
         switch (taxonKey.getType()) {
             case PLACEHOLDER:
@@ -995,7 +995,7 @@ public class Taxonomy implements Reporter {
      */
     public TaxonomicElement findElement(NomenclaturalCode code, String name, NameProvider provider, RankType rank) {
         NameKey nameKey = null;
-        nameKey = this.analyser.analyse(code, name, null, rank, provider.isLoose()).toNameKey();
+        nameKey = this.analyser.analyse(code, name, null, rank, null, provider.isLoose()).toNameKey();
         if (nameKey.isUncoded())
             return this.bareNames.get(nameKey);
         if (nameKey.isUnranked())

--- a/src/main/java/au/org/ala/names/index/UnrankedStrategy.java
+++ b/src/main/java/au/org/ala/names/index/UnrankedStrategy.java
@@ -15,8 +15,13 @@ import java.util.Set;
  * @copyright Copyright &copy; 2018 Atlas of Living Australia
  */
 public enum UnrankedStrategy {
-    ALL(TaxonomicType.values()),
-    SYNONYMS(
+    /** Reassign all unranked taxa. If there isn't a matching ranked taxon, then infer rank. */
+    ALL_INFER(true, TaxonomicType.values()),
+    /** Reassign all unranked taxa with a matching, ranked name */
+    ALL(false, TaxonomicType.values()),
+    /** Reassign all synonyms. If there isn't a matching ranked taxon, then infer rank. */
+    SYNONYMS_INFER(
+            true,
             TaxonomicType.HOMOTYPIC_SYNONYM,
             TaxonomicType.INFERRED_SYNONYM,
             TaxonomicType.SYNONYM,
@@ -24,14 +29,37 @@ public enum UnrankedStrategy {
             TaxonomicType.OBJECTIVE_SYNONYM,
             TaxonomicType.PRO_PARTE_SYNONYM,
             TaxonomicType.SUBJECTIVE_SYNONYM),
-    NONE();
+    /** Reassign all synonyms with a matching, ranked name */
+    SYNONYMS(
+            false,
+            TaxonomicType.HOMOTYPIC_SYNONYM,
+            TaxonomicType.INFERRED_SYNONYM,
+            TaxonomicType.SYNONYM,
+            TaxonomicType.HETEROTYPIC_SYNONYM,
+            TaxonomicType.OBJECTIVE_SYNONYM,
+            TaxonomicType.PRO_PARTE_SYNONYM,
+            TaxonomicType.SUBJECTIVE_SYNONYM),
+    /** Reassign nothing */
+    NONE(false);
 
     /** The taxonomic types to reassign */
     private Set<TaxonomicType> reassign;
+    /** Infer rank, even if there is no reassignable rank */
+    private boolean inferRank;
 
     /** Build for a specific set of taxonomic types */
-    private UnrankedStrategy(TaxonomicType... types) {
+    private UnrankedStrategy(boolean inferRank, TaxonomicType... types) {
+        this.inferRank = inferRank;
         this.reassign = new HashSet<>(Arrays.asList(types));
+    }
+
+    /**
+     * Infer a rank from the taxon, if not able to find a matching, ranked taxon
+     *
+     * @return True if rank is to be inferred
+     */
+    public boolean isInferRank() {
+        return this.inferRank;
     }
 
     /**

--- a/src/main/java/au/org/ala/names/index/UnrankedStrategy.java
+++ b/src/main/java/au/org/ala/names/index/UnrankedStrategy.java
@@ -19,6 +19,30 @@ public enum UnrankedStrategy {
     ALL_INFER(true, TaxonomicType.values()),
     /** Reassign all unranked taxa with a matching, ranked name */
     ALL(false, TaxonomicType.values()),
+    /** Reassign any useful inferred taxa and synonyms. If there isn't a matching unranked taxon, the infer rank */
+    INFERRED_AND_SYNONYMS_INFER(
+            true,
+            TaxonomicType.INFERRED_UNPLACED,
+            TaxonomicType.INFERRED_SYNONYM,
+            TaxonomicType.INFERRED_ACCEPTED,
+            TaxonomicType.HOMOTYPIC_SYNONYM,
+            TaxonomicType.SYNONYM,
+            TaxonomicType.HETEROTYPIC_SYNONYM,
+            TaxonomicType.OBJECTIVE_SYNONYM,
+            TaxonomicType.PRO_PARTE_SYNONYM,
+            TaxonomicType.SUBJECTIVE_SYNONYM),
+    /** Reassign any useful inferred taxa and synonyms. */
+    INFERRED_AND_SYNONYMS(
+            false,
+            TaxonomicType.INFERRED_UNPLACED,
+            TaxonomicType.INFERRED_SYNONYM,
+            TaxonomicType.INFERRED_ACCEPTED,
+            TaxonomicType.HOMOTYPIC_SYNONYM,
+            TaxonomicType.SYNONYM,
+            TaxonomicType.HETEROTYPIC_SYNONYM,
+            TaxonomicType.OBJECTIVE_SYNONYM,
+            TaxonomicType.PRO_PARTE_SYNONYM,
+            TaxonomicType.SUBJECTIVE_SYNONYM),
     /** Reassign all synonyms. If there isn't a matching ranked taxon, then infer rank. */
     SYNONYMS_INFER(
             true,

--- a/src/main/java/au/org/ala/names/model/RankType.java
+++ b/src/main/java/au/org/ala/names/model/RankType.java
@@ -101,6 +101,8 @@ public enum RankType {
     HYBRID(8150, "hybrid", null, null, 8150, true),
     SUPRAGENERICNAME(8200, "supragenericname", Rank.SUPRAGENERIC_NAME, null, 8200, true, "http://rs.tdwg.org/ontology/voc/TaxonRank#SupragenericTaxon"),
     INFORMAL(-1, "informal", null, null, 100000, true),
+    INCERTAE_SEDIS(-1, "incertae sedis", null, null, 150000, true),
+    SPECIES_INQUIRENDA(-1, "species inquirenda", null, null, 160000, true),
     UNRANKED(0, "unranked", Rank.UNRANKED, null, 200000, true);
 
 

--- a/src/main/java/au/org/ala/names/model/TaxonomicType.java
+++ b/src/main/java/au/org/ala/names/model/TaxonomicType.java
@@ -11,41 +11,43 @@ package au.org.ala.names.model;
  */
 public enum TaxonomicType {
     /** A taxon explicitly placed in the taxonomic tree */
-    ACCEPTED("accepted", TaxonomicTypeGroup.ACCEPTED, true, true, false),
+    ACCEPTED("accepted", TaxonomicTypeGroup.ACCEPTED, true, true, false, false),
     /** A taxon placed in the taxonomiuc tree by an algorithm */
-    INFERRED_ACCEPTED("inferredAccepted", TaxonomicTypeGroup.ACCEPTED, true, true, false),
+    INFERRED_ACCEPTED("inferredAccepted", TaxonomicTypeGroup.ACCEPTED, true, true, false, false),
     /** A generic synonym */
-    SYNONYM("synonym", TaxonomicTypeGroup.SYNONYM, true, false, true),
+    SYNONYM("synonym", TaxonomicTypeGroup.SYNONYM, true, false, true, false),
     /** A homotypic synonym (botany). A nomenclatural synonym, meaning that the same taxon has gone under a different name. This can occur when two people describe the same species. @see #OBJECTIVE_SYNONYM */
-    HOMOTYPIC_SYNONYM("homotypicSynonym", TaxonomicTypeGroup.SYNONYM, true, false, true),
+    HOMOTYPIC_SYNONYM("homotypicSynonym", TaxonomicTypeGroup.SYNONYM, true, false, true, false),
     /** An objective synonym (zoology). A nomenclatural synonym, meaning that the same taxon has gone under a different name. This can occur when two people describe the same species. @see #HOMOTYPIC_SYNONYM */
-    OBJECTIVE_SYNONYM("objectiveSynonym", TaxonomicTypeGroup.SYNONYM, true, false, true),
+    OBJECTIVE_SYNONYM("objectiveSynonym", TaxonomicTypeGroup.SYNONYM, true, false, true, false),
     /** A heterotypic synonym (botany). A taxonomic synonym, meaning that a species that was originally considered to be separate has been lumped into another species. @see #SUBJECTIVE_SYNONYM  */
-    HETEROTYPIC_SYNONYM("heterotypicSynonym", TaxonomicTypeGroup.SYNONYM, true, false, true),
+    HETEROTYPIC_SYNONYM("heterotypicSynonym", TaxonomicTypeGroup.SYNONYM, true, false, true, false),
     /** A subjective synonym (zoology). A taxonomic synonym, meaning that a species that was originally considered to be separate has been lumped into another species. A subjective synonym, since whether they are synonymns or not is a matter of opinion. @see #HETEROTYPIC_SYNONYM */
-    SUBJECTIVE_SYNONYM("subjectiveSynonym", TaxonomicTypeGroup.SYNONYM, true, false, true),
+    SUBJECTIVE_SYNONYM("subjectiveSynonym", TaxonomicTypeGroup.SYNONYM, true, false, true, false),
     /** A synonym where part of an original taxon has been divided. This means that the original name may still be in use or may have been mapped onto several other taxa. */
-    PRO_PARTE_SYNONYM("proParteSynonym", TaxonomicTypeGroup.SYNONYM, true, false, true),
+    PRO_PARTE_SYNONYM("proParteSynonym", TaxonomicTypeGroup.SYNONYM, true, false, true, false),
     /** A name incorrectly applied in a publication to a different species. However, the name itself is perfectly valid and has its own taxon. */
-    MISAPPLIED("misapplied", TaxonomicTypeGroup.MISAPPLIED,  false, false, true),
+    MISAPPLIED("misapplied", TaxonomicTypeGroup.MISAPPLIED,  false, false, true, false),
     /** A synonym inferred by an algorithm */
-    INFERRED_SYNONYM("inferredSynonym", TaxonomicTypeGroup.SYNONYM, true, false, true),
+    INFERRED_SYNONYM("inferredSynonym", TaxonomicTypeGroup.SYNONYM, true, false, true, false),
     /** A name that shouldn't be used, since it refers to something not found in the region of the occurrence record. */
-    EXCLUDED("excluded", TaxonomicTypeGroup.EXCLUDED, false, false, false),
+    EXCLUDED("excluded", TaxonomicTypeGroup.EXCLUDED, false, false, false, false),
     /** A taxon of uncertain placement */
-    INCERTAE_SEDIS("incertaeSedis", TaxonomicTypeGroup.INCERTAE_SEDIS, false, true, false),
+    INCERTAE_SEDIS("incertaeSedis", TaxonomicTypeGroup.INCERTAE_SEDIS, false, true, false, true),
+    /** A taxon of doubtful identity, requiring further investigation, but placed in the taxonomy */
+    SPECIES_INQUIRENDA("speciesInquirenda", TaxonomicTypeGroup.INCERTAE_SEDIS, false, true, false, true),
     /** An unplaced taxon */
-    UNPLACED("unplaced", TaxonomicTypeGroup.UNPLACED, false, false, false, "unknown"),
+    UNPLACED("unplaced", TaxonomicTypeGroup.UNPLACED, false, false, false, true, "unknown"),
     /** An inferred unplaced taxon */
-    INFERRED_UNPLACED("inferredUnplaced", TaxonomicTypeGroup.UNPLACED, false, false, false),
+    INFERRED_UNPLACED("inferredUnplaced", TaxonomicTypeGroup.UNPLACED, false, false, false, true),
     /** An invalid taxon (usually needed to allow parents to be found */
-    INVALID("invalid", TaxonomicTypeGroup.INVALID, false, false, false),
+    INVALID("invalid", TaxonomicTypeGroup.INVALID, false, false, false, false),
     /** An inferred invalid taxon (usually needed to allow parents to be found */
-    INFERRED_INVALID("inferredInvalid", TaxonomicTypeGroup.INVALID, false, false, false),
+    INFERRED_INVALID("inferredInvalid", TaxonomicTypeGroup.INVALID, false, false, false, false),
     /** A dubious taxon */
-    DOUBTFUL("doubtful", TaxonomicTypeGroup.DOUBTFUL, false, false, false),
+    DOUBTFUL("doubtful", TaxonomicTypeGroup.DOUBTFUL, false, false, false, false),
     /** A name that occurs in other literature. */
-    MISCELLANEOUS_LITERATURE("miscellaneousLiterature", TaxonomicTypeGroup.MISCELLANEOUS, false, false, false);
+    MISCELLANEOUS_LITERATURE("miscellaneousLiterature", TaxonomicTypeGroup.MISCELLANEOUS, false, false, false, false);
 
     /** The standardised term */
     private String term;
@@ -57,15 +59,18 @@ public enum TaxonomicType {
     private boolean accepted;
     /** Is this a synonym */
     private boolean synonym;
+    /** Is this a placeholder of some sort */
+    private boolean placeholder;
     /** Additional labels */
     private String[] labels;
 
-    TaxonomicType(String term, TaxonomicTypeGroup group, boolean primary, boolean accepted, boolean synonym, String... labels) {
+    TaxonomicType(String term, TaxonomicTypeGroup group, boolean primary, boolean accepted, boolean synonym, boolean placeholder, String... labels) {
         this.term = term;
         this.group = group;
         this.primary = primary;
         this.accepted = accepted;
         this.synonym = synonym;
+        this.placeholder = placeholder;
         this.labels = labels;
     }
 
@@ -116,6 +121,15 @@ public enum TaxonomicType {
      */
     public boolean isSynonym() {
         return synonym;
+    }
+
+    /**
+     * Does this taxonomic type represent a placeholder
+     *
+     * @return True if a placeholder
+     */
+    public boolean isPlaceholder() {
+        return placeholder;
     }
 
     /**

--- a/src/main/java/au/org/ala/names/model/TaxonomicType.java
+++ b/src/main/java/au/org/ala/names/model/TaxonomicType.java
@@ -11,43 +11,45 @@ package au.org.ala.names.model;
  */
 public enum TaxonomicType {
     /** A taxon explicitly placed in the taxonomic tree */
-    ACCEPTED("accepted", TaxonomicTypeGroup.ACCEPTED, true, true, false, false, false),
+    ACCEPTED("accepted", TaxonomicTypeGroup.ACCEPTED, true, true, false, false, false, true),
     /** A taxon placed in the taxonomiuc tree by an algorithm */
-    INFERRED_ACCEPTED("inferredAccepted", TaxonomicTypeGroup.ACCEPTED, true, true, false, false, false),
+    INFERRED_ACCEPTED("inferredAccepted", TaxonomicTypeGroup.ACCEPTED, true, true, false, false, false, true),
     /** A generic synonym */
-    SYNONYM("synonym", TaxonomicTypeGroup.SYNONYM, true, false, true, false, false),
-    /** A homotypic synonym (botany). A nomenclatural synonym, meaning that the same taxon has gone under a different name. This can occur when two people describe the same species. @see #OBJECTIVE_SYNONYM */
-    HOMOTYPIC_SYNONYM("homotypicSynonym", TaxonomicTypeGroup.SYNONYM, true, false, true, false, false),
-    /** An objective synonym (zoology). A nomenclatural synonym, meaning that the same taxon has gone under a different name. This can occur when two people describe the same species. @see #HOMOTYPIC_SYNONYM */
-    OBJECTIVE_SYNONYM("objectiveSynonym", TaxonomicTypeGroup.SYNONYM, true, false, true, false, false),
-    /** A heterotypic synonym (botany). A taxonomic synonym, meaning that a species that was originally considered to be separate has been lumped into another species. @see #SUBJECTIVE_SYNONYM  */
-    HETEROTYPIC_SYNONYM("heterotypicSynonym", TaxonomicTypeGroup.SYNONYM, true, false, true, false, false),
-    /** A subjective synonym (zoology). A taxonomic synonym, meaning that a species that was originally considered to be separate has been lumped into another species. A subjective synonym, since whether they are synonymns or not is a matter of opinion. @see #HETEROTYPIC_SYNONYM */
-    SUBJECTIVE_SYNONYM("subjectiveSynonym", TaxonomicTypeGroup.SYNONYM, true, false, true, false, false),
+    SYNONYM("synonym", TaxonomicTypeGroup.SYNONYM, true, false, true, false, false, true),
+    /** A homotypic synonym (botany, true). A nomenclatural synonym, meaning that the same taxon has gone under a different name. This can occur when two people describe the same species. @see #OBJECTIVE_SYNONYM */
+    HOMOTYPIC_SYNONYM("homotypicSynonym", TaxonomicTypeGroup.SYNONYM, true, false, true, false, false, true),
+    /** An objective synonym (zoology, true). A nomenclatural synonym, meaning that the same taxon has gone under a different name. This can occur when two people describe the same species. @see #HOMOTYPIC_SYNONYM */
+    OBJECTIVE_SYNONYM("objectiveSynonym", TaxonomicTypeGroup.SYNONYM, true, false, true, false, false, true),
+    /** A heterotypic synonym (botany, true). A taxonomic synonym, meaning that a species that was originally considered to be separate has been lumped into another species. @see #SUBJECTIVE_SYNONYM  */
+    HETEROTYPIC_SYNONYM("heterotypicSynonym", TaxonomicTypeGroup.SYNONYM, true, false, true, false, false, true),
+    /** A subjective synonym (zoology, true). A taxonomic synonym, meaning that a species that was originally considered to be separate has been lumped into another species. A subjective synonym, since whether they are synonymns or not is a matter of opinion. @see #HETEROTYPIC_SYNONYM */
+    SUBJECTIVE_SYNONYM("subjectiveSynonym", TaxonomicTypeGroup.SYNONYM, true, false, true, false, false, true),
     /** A synonym where part of an original taxon has been divided. This means that the original name may still be in use or may have been mapped onto several other taxa. */
-    PRO_PARTE_SYNONYM("proParteSynonym", TaxonomicTypeGroup.SYNONYM, true, false, true, false, false),
+    PRO_PARTE_SYNONYM("proParteSynonym", TaxonomicTypeGroup.SYNONYM, true, false, true, false, false, true),
     /** A name incorrectly applied in a publication to a different species. However, the name itself is perfectly valid and has its own taxon. */
-    MISAPPLIED("misapplied", TaxonomicTypeGroup.MISAPPLIED,  false, false, true, false, false),
+    MISAPPLIED("misapplied", TaxonomicTypeGroup.MISAPPLIED,  false, false, true, false, false, true),
     /** A synonym inferred by an algorithm */
-    INFERRED_SYNONYM("inferredSynonym", TaxonomicTypeGroup.SYNONYM, true, false, true, false, false),
+    INFERRED_SYNONYM("inferredSynonym", TaxonomicTypeGroup.SYNONYM, true, false, true, false, false, true),
     /** A name that shouldn't be used, since it refers to something not found in the region of the occurrence record. */
-    EXCLUDED("excluded", TaxonomicTypeGroup.EXCLUDED, false, false, false, false, false),
+    EXCLUDED("excluded", TaxonomicTypeGroup.EXCLUDED, false, false, false, false, false, true),
     /** A taxon of uncertain placement */
-    INCERTAE_SEDIS("incertaeSedis", TaxonomicTypeGroup.INCERTAE_SEDIS, false, true, false, false, true),
+    INCERTAE_SEDIS("incertaeSedis", TaxonomicTypeGroup.INCERTAE_SEDIS, false, true, false, false, true, true),
     /** A taxon of doubtful identity, requiring further investigation, but placed in the taxonomy */
-    SPECIES_INQUIRENDA("speciesInquirenda", TaxonomicTypeGroup.INCERTAE_SEDIS, false, true, false, false, true),
-    /** An unplaced taxon (not a placeholder, just unplaced in the hierarchy) */
-    UNPLACED("unplaced", TaxonomicTypeGroup.UNPLACED, false, false, false, true, false, "unknown"),
-    /** An inferred unplaced taxon (also not a placeholder, just unplaced in the hierarchy) */
-    INFERRED_UNPLACED("inferredUnplaced", TaxonomicTypeGroup.UNPLACED, false, false, false, true, false),
+    SPECIES_INQUIRENDA("speciesInquirenda", TaxonomicTypeGroup.INCERTAE_SEDIS, false, true, false, false, true, true),
+    /** An unplaced taxon (not a placeholder, just unplaced in the hierarchy, true) */
+    UNPLACED("unplaced", TaxonomicTypeGroup.UNPLACED, false, false, false, true, false, true, "unknown"),
+    /** An inferred unplaced taxon (also not a placeholder, just unplaced in the hierarchy, true) */
+    INFERRED_UNPLACED("inferredUnplaced", TaxonomicTypeGroup.UNPLACED, false, false, false, true, false, true),
     /** An invalid taxon (usually needed to allow parents to be found */
-    INVALID("invalid", TaxonomicTypeGroup.INVALID, false, false, false, false, false),
+    INVALID("invalid", TaxonomicTypeGroup.INVALID, false, false, false, false, false, true),
     /** An inferred invalid taxon (usually needed to allow parents to be found */
-    INFERRED_INVALID("inferredInvalid", TaxonomicTypeGroup.INVALID, false, false, false, false, false),
+    INFERRED_INVALID("inferredInvalid", TaxonomicTypeGroup.INVALID, false, false, false, false, false, true),
     /** A dubious taxon */
-    DOUBTFUL("doubtful", TaxonomicTypeGroup.DOUBTFUL, false, false, false, false, false),
+    DOUBTFUL("doubtful", TaxonomicTypeGroup.DOUBTFUL, false, false, false, false, false, true),
     /** A name that occurs in other literature. */
-    MISCELLANEOUS_LITERATURE("miscellaneousLiterature", TaxonomicTypeGroup.MISCELLANEOUS, false, false, false, false, false);
+    MISCELLANEOUS_LITERATURE("miscellaneousLiterature", TaxonomicTypeGroup.MISCELLANEOUS, false, false, false, true, false, true),
+    /** A pseudo-taxon created to link an odd source of a name to a result, always linked to an actual taxon. A principal because we want to capture this instance */
+    PSEUDO_TAXON("pseudoTaxon", TaxonomicTypeGroup.MISCELLANEOUS, true, false, true, false, false, false);
 
     /** The standardised term */
     private String term;
@@ -63,10 +65,12 @@ public enum TaxonomicType {
     private boolean unplaced;
     /** Is this a placeholder of some sort */
     private boolean placeholder;
+    /** Include in the output */
+    private boolean output;
     /** Additional labels */
     private String[] labels;
 
-    TaxonomicType(String term, TaxonomicTypeGroup group, boolean primary, boolean accepted, boolean synonym, boolean unplaced, boolean placeholder, String... labels) {
+    TaxonomicType(String term, TaxonomicTypeGroup group, boolean primary, boolean accepted, boolean synonym, boolean unplaced, boolean placeholder, boolean output, String... labels) {
         this.term = term;
         this.group = group;
         this.primary = primary;
@@ -74,6 +78,7 @@ public enum TaxonomicType {
         this.synonym = synonym;
         this.unplaced = unplaced;
         this.placeholder = placeholder;
+        this.output = output;
         this.labels = labels;
     }
 
@@ -142,6 +147,15 @@ public enum TaxonomicType {
      */
     public boolean isPlaceholder() {
         return placeholder;
+    }
+
+    /**
+     * Should an instance of this taxonomic type be output?
+     *
+     * @return True if outputable
+     */
+    public boolean isOutput() {
+        return output;
     }
 
     /**

--- a/src/main/java/au/org/ala/names/model/TaxonomicType.java
+++ b/src/main/java/au/org/ala/names/model/TaxonomicType.java
@@ -11,43 +11,43 @@ package au.org.ala.names.model;
  */
 public enum TaxonomicType {
     /** A taxon explicitly placed in the taxonomic tree */
-    ACCEPTED("accepted", TaxonomicTypeGroup.ACCEPTED, true, true, false, false),
+    ACCEPTED("accepted", TaxonomicTypeGroup.ACCEPTED, true, true, false, false, false),
     /** A taxon placed in the taxonomiuc tree by an algorithm */
-    INFERRED_ACCEPTED("inferredAccepted", TaxonomicTypeGroup.ACCEPTED, true, true, false, false),
+    INFERRED_ACCEPTED("inferredAccepted", TaxonomicTypeGroup.ACCEPTED, true, true, false, false, false),
     /** A generic synonym */
-    SYNONYM("synonym", TaxonomicTypeGroup.SYNONYM, true, false, true, false),
+    SYNONYM("synonym", TaxonomicTypeGroup.SYNONYM, true, false, true, false, false),
     /** A homotypic synonym (botany). A nomenclatural synonym, meaning that the same taxon has gone under a different name. This can occur when two people describe the same species. @see #OBJECTIVE_SYNONYM */
-    HOMOTYPIC_SYNONYM("homotypicSynonym", TaxonomicTypeGroup.SYNONYM, true, false, true, false),
+    HOMOTYPIC_SYNONYM("homotypicSynonym", TaxonomicTypeGroup.SYNONYM, true, false, true, false, false),
     /** An objective synonym (zoology). A nomenclatural synonym, meaning that the same taxon has gone under a different name. This can occur when two people describe the same species. @see #HOMOTYPIC_SYNONYM */
-    OBJECTIVE_SYNONYM("objectiveSynonym", TaxonomicTypeGroup.SYNONYM, true, false, true, false),
+    OBJECTIVE_SYNONYM("objectiveSynonym", TaxonomicTypeGroup.SYNONYM, true, false, true, false, false),
     /** A heterotypic synonym (botany). A taxonomic synonym, meaning that a species that was originally considered to be separate has been lumped into another species. @see #SUBJECTIVE_SYNONYM  */
-    HETEROTYPIC_SYNONYM("heterotypicSynonym", TaxonomicTypeGroup.SYNONYM, true, false, true, false),
+    HETEROTYPIC_SYNONYM("heterotypicSynonym", TaxonomicTypeGroup.SYNONYM, true, false, true, false, false),
     /** A subjective synonym (zoology). A taxonomic synonym, meaning that a species that was originally considered to be separate has been lumped into another species. A subjective synonym, since whether they are synonymns or not is a matter of opinion. @see #HETEROTYPIC_SYNONYM */
-    SUBJECTIVE_SYNONYM("subjectiveSynonym", TaxonomicTypeGroup.SYNONYM, true, false, true, false),
+    SUBJECTIVE_SYNONYM("subjectiveSynonym", TaxonomicTypeGroup.SYNONYM, true, false, true, false, false),
     /** A synonym where part of an original taxon has been divided. This means that the original name may still be in use or may have been mapped onto several other taxa. */
-    PRO_PARTE_SYNONYM("proParteSynonym", TaxonomicTypeGroup.SYNONYM, true, false, true, false),
+    PRO_PARTE_SYNONYM("proParteSynonym", TaxonomicTypeGroup.SYNONYM, true, false, true, false, false),
     /** A name incorrectly applied in a publication to a different species. However, the name itself is perfectly valid and has its own taxon. */
-    MISAPPLIED("misapplied", TaxonomicTypeGroup.MISAPPLIED,  false, false, true, false),
+    MISAPPLIED("misapplied", TaxonomicTypeGroup.MISAPPLIED,  false, false, true, false, false),
     /** A synonym inferred by an algorithm */
-    INFERRED_SYNONYM("inferredSynonym", TaxonomicTypeGroup.SYNONYM, true, false, true, false),
+    INFERRED_SYNONYM("inferredSynonym", TaxonomicTypeGroup.SYNONYM, true, false, true, false, false),
     /** A name that shouldn't be used, since it refers to something not found in the region of the occurrence record. */
-    EXCLUDED("excluded", TaxonomicTypeGroup.EXCLUDED, false, false, false, false),
+    EXCLUDED("excluded", TaxonomicTypeGroup.EXCLUDED, false, false, false, false, false),
     /** A taxon of uncertain placement */
-    INCERTAE_SEDIS("incertaeSedis", TaxonomicTypeGroup.INCERTAE_SEDIS, false, true, false, true),
+    INCERTAE_SEDIS("incertaeSedis", TaxonomicTypeGroup.INCERTAE_SEDIS, false, true, false, false, true),
     /** A taxon of doubtful identity, requiring further investigation, but placed in the taxonomy */
-    SPECIES_INQUIRENDA("speciesInquirenda", TaxonomicTypeGroup.INCERTAE_SEDIS, false, true, false, true),
-    /** An unplaced taxon */
-    UNPLACED("unplaced", TaxonomicTypeGroup.UNPLACED, false, false, false, true, "unknown"),
-    /** An inferred unplaced taxon */
-    INFERRED_UNPLACED("inferredUnplaced", TaxonomicTypeGroup.UNPLACED, false, false, false, true),
+    SPECIES_INQUIRENDA("speciesInquirenda", TaxonomicTypeGroup.INCERTAE_SEDIS, false, true, false, false, true),
+    /** An unplaced taxon (not a placeholder, just unplaced in the hierarchy) */
+    UNPLACED("unplaced", TaxonomicTypeGroup.UNPLACED, false, false, false, true, false, "unknown"),
+    /** An inferred unplaced taxon (also not a placeholder, just unplaced in the hierarchy) */
+    INFERRED_UNPLACED("inferredUnplaced", TaxonomicTypeGroup.UNPLACED, false, false, false, true, false),
     /** An invalid taxon (usually needed to allow parents to be found */
-    INVALID("invalid", TaxonomicTypeGroup.INVALID, false, false, false, false),
+    INVALID("invalid", TaxonomicTypeGroup.INVALID, false, false, false, false, false),
     /** An inferred invalid taxon (usually needed to allow parents to be found */
-    INFERRED_INVALID("inferredInvalid", TaxonomicTypeGroup.INVALID, false, false, false, false),
+    INFERRED_INVALID("inferredInvalid", TaxonomicTypeGroup.INVALID, false, false, false, false, false),
     /** A dubious taxon */
-    DOUBTFUL("doubtful", TaxonomicTypeGroup.DOUBTFUL, false, false, false, false),
+    DOUBTFUL("doubtful", TaxonomicTypeGroup.DOUBTFUL, false, false, false, false, false),
     /** A name that occurs in other literature. */
-    MISCELLANEOUS_LITERATURE("miscellaneousLiterature", TaxonomicTypeGroup.MISCELLANEOUS, false, false, false, false);
+    MISCELLANEOUS_LITERATURE("miscellaneousLiterature", TaxonomicTypeGroup.MISCELLANEOUS, false, false, false, false, false);
 
     /** The standardised term */
     private String term;
@@ -59,17 +59,20 @@ public enum TaxonomicType {
     private boolean accepted;
     /** Is this a synonym */
     private boolean synonym;
+    /** Is this an unplaced taxon, meaning that it is only partially located in the taxonomy */
+    private boolean unplaced;
     /** Is this a placeholder of some sort */
     private boolean placeholder;
     /** Additional labels */
     private String[] labels;
 
-    TaxonomicType(String term, TaxonomicTypeGroup group, boolean primary, boolean accepted, boolean synonym, boolean placeholder, String... labels) {
+    TaxonomicType(String term, TaxonomicTypeGroup group, boolean primary, boolean accepted, boolean synonym, boolean unplaced, boolean placeholder, String... labels) {
         this.term = term;
         this.group = group;
         this.primary = primary;
         this.accepted = accepted;
         this.synonym = synonym;
+        this.unplaced = unplaced;
         this.placeholder = placeholder;
         this.labels = labels;
     }
@@ -121,6 +124,15 @@ public enum TaxonomicType {
      */
     public boolean isSynonym() {
         return synonym;
+    }
+
+    /**
+     * Does this taxonomic type represent an unplaced taxon (ie one that is not accurately located)
+     *
+     * @return True if unplaced
+     */
+    public boolean isUnplaced() {
+        return unplaced;
     }
 
     /**

--- a/src/main/java/au/org/ala/names/model/TaxonomicTypeGroup.java
+++ b/src/main/java/au/org/ala/names/model/TaxonomicTypeGroup.java
@@ -13,6 +13,7 @@ public enum TaxonomicTypeGroup {
     EXCLUDED,
     MISCELLANEOUS,
     INCERTAE_SEDIS,
+    SPECIES_INQUIRENDA,
     UNPLACED,
     DOUBTFUL,
     INVALID

--- a/src/main/java/au/org/ala/names/model/VernacularType.java
+++ b/src/main/java/au/org/ala/names/model/VernacularType.java
@@ -1,0 +1,89 @@
+package au.org.ala.names.model;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Types of vernacular names.
+ *
+ * @author Doug Palmer &lt;Doug.Palmer@csiro.au&gt;
+ * @copyright Copyright &copy; 2018 Atlas of Living Australia
+ */
+public enum VernacularType {
+    STANDARD("standard", 900, false),
+    PREFERRED("preferred", 800, false),
+    COMMON("common", 700, false, "vernacular"),
+    TRADITIONAL_KNOWLEDGE("traditionalKnowledge", 600, false, "traditional knowledge", "traditional"),
+    LEGISLATIVE("legislated", 500, true, "legislative"),
+    MISCELLANEOUS_LITERATURE("miscellaneousLiterature", 400, true, "miscellaneous literature", "misc lit"),
+    LOCAL("local", 300, false);
+
+    private static Map<String, VernacularType> nameMap = new HashMap<>();
+
+    static {
+        for (VernacularType type: VernacularType.values()) {
+            nameMap.put(type.term, type);
+            for (String alt: type.altTerms)
+                nameMap.put(alt, type);
+        }
+    }
+
+    /** The preferred term */
+    private String term;
+    /** Any other terms that might descript this name */
+    private String[] altTerms;
+    /** Is this a pseudo-scientific name? */
+    private boolean pseudoScientific;
+    /** The name priority */
+    private int priority;
+
+    VernacularType(String term, int priority, boolean pseudoScientific, String... altTerms) {
+        this.term = term;
+        this.priority = priority;
+        this.pseudoScientific = pseudoScientific;
+        this.altTerms = altTerms;
+    }
+
+    /**
+     * Get the vocabulary term
+     *
+     * @return The term
+     */
+    public String getTerm() {
+        return term;
+    }
+
+    /**
+     * Is this a pseudo-scientific name?
+     * <p>
+     * Pseudo-scientific names look like a latinised scientific name but are a by-product of other sources
+     * and are treated as vernacular names.
+     * </p>
+     *
+     * @return True is pseudo-scientific
+     */
+    public boolean isPseudoScientific() {
+        return pseudoScientific;
+    }
+
+    /**
+     * Get the priority, higher names should come first.
+     *
+     * @return The priority
+     */
+    public int getPriority() {
+        return priority;
+    }
+
+    /**
+     * Get a type based on a vocabulary term.
+     *
+     * @param term The term to look up
+     * @param dft The default value if not found
+     *
+     * @return The type
+     */
+    public static VernacularType forTerm(String term, VernacularType dft) {
+        return nameMap.getOrDefault(term, dft);
+    }
+}

--- a/src/main/java/au/org/ala/names/search/ALANameIndexer.java
+++ b/src/main/java/au/org/ala/names/search/ALANameIndexer.java
@@ -897,7 +897,7 @@ public class ALANameIndexer {
             if (cn != null && cn.isParsableType() && !cn.isIndetermined()
                     // a scientific name with some informal addition like "cf." or indetermined like Abies spec.
                     // ALSO prevent subgenus because they parse down to genus plus author
-                    && cn.getType() != NameType.INFORMAL && !"6500".equals(rank) && cn.getType() != NameType.DOUBTFUL)
+                    && cn.getType() != NameType.INFORMAL && !"6500".equals(rank) && cn.getType() != NameType.DOUBTFUL && !nameSet.contains(cn.canonicalName()))
             {
                 Field f2 = new TextField(NameIndexField.NAME.toString(), cn.canonicalName(), Store.YES);
                 f2.setBoost(boost);

--- a/src/main/java/au/org/ala/names/search/ALANameIndexer.java
+++ b/src/main/java/au/org/ala/names/search/ALANameIndexer.java
@@ -417,6 +417,9 @@ public class ALANameIndexer {
 
     /**
      * Indexes the IRMNG homonyms from the supplied DWCA direcory
+     * <p>
+     * Only accept those with a taxonomic status of accepted
+     * </p>
      * @param iw The index writer to write the lucene docs to
      * @param archiveDirectory  The directory in which the IRMNG DWCA has been unzipped.
      * @throws Exception
@@ -427,8 +430,11 @@ public class ALANameIndexer {
         Archive archive = ArchiveFactory.openArchive(new File(archiveDirectory));
         Iterator<Record> it = archive.getCore().iterator();
         while (it.hasNext()) {
-            Document doc = new Document();
             Record dwcr = it.next();
+            String taxonomicStatus = dwcr.value(DwcTerm.taxonomicStatus);
+            if (taxonomicStatus == null || !taxonomicStatus.equalsIgnoreCase("accepted"))
+                continue;
+            Document doc = new Document();
             String kingdom = dwcr.value(DwcTerm.kingdom);
             if (StringUtils.isNotEmpty(kingdom)) {
                 doc.add(new TextField(RankType.KINGDOM.getRank(), kingdom, Store.YES));
@@ -897,11 +903,13 @@ public class ALANameIndexer {
             if (cn != null && cn.isParsableType() && !cn.isIndetermined()
                     // a scientific name with some informal addition like "cf." or indetermined like Abies spec.
                     // ALSO prevent subgenus because they parse down to genus plus author
-                    && cn.getType() != NameType.INFORMAL && !"6500".equals(rank) && cn.getType() != NameType.DOUBTFUL && !nameSet.contains(cn.canonicalName()))
+                    && cn.getType() != NameType.INFORMAL && !"6500".equals(rank) && cn.getType() != NameType.DOUBTFUL)
             {
-                Field f2 = new TextField(NameIndexField.NAME.toString(), cn.canonicalName(), Store.YES);
-                f2.setBoost(boost);
-                doc.add(f2);
+                if (!nameSet.contains(cn.canonicalName())) {
+                    Field f2 = new TextField(NameIndexField.NAME.toString(), cn.canonicalName(), Store.YES);
+                    f2.setBoost(boost);
+                    doc.add(f2);
+                }
                 if (specificEpithet == null && cn.isBinomial()) {
                     //check to see if we need to determine the epithets from the parse
                     soundexGenus = cn.getGenusOrAbove();
@@ -949,12 +957,18 @@ public class ALANameIndexer {
                 doc.add(new TextField(NameIndexField.GENUS_EX.toString(), TaxonNameSoundEx.treatWord(soundexGenus, "genus"), Store.YES));
             }
             if (StringUtils.isNotBlank(specificEpithet)) {
-                doc.add(new TextField(NameIndexField.SPECIES_EX.toString(), TaxonNameSoundEx.treatWord(specificEpithet, "species"), Store.YES));
+                String soundex = TaxonNameSoundEx.treatWord(specificEpithet, "species");
+                if (soundex == null)
+                    soundex = "<null>";
+                doc.add(new TextField(NameIndexField.SPECIES_EX.toString(), soundex, Store.YES));
             } else if (StringUtils.isNotBlank(soundexGenus)) {
                 doc.add(new TextField(NameIndexField.SPECIES_EX.toString(), "<null>", Store.YES));
             }
             if (StringUtils.isNotBlank(infraspecificEpithet)) {
-                doc.add(new TextField(NameIndexField.INFRA_EX.toString(), TaxonNameSoundEx.treatWord(infraspecificEpithet, "species"), Store.YES));
+                String soundex = TaxonNameSoundEx.treatWord(infraspecificEpithet, "species");
+                if (soundex == null)
+                    soundex = "<null>";
+                doc.add(new TextField(NameIndexField.INFRA_EX.toString(), soundex, Store.YES));
             } else if (StringUtils.isNotBlank(specificEpithet)) {
                 //make searching for an empty infraspecific soudex easier
                 doc.add(new TextField(NameIndexField.INFRA_EX.toString(), "<null>", Store.YES));

--- a/src/main/java/au/org/ala/names/search/DwcaNameIndexer.java
+++ b/src/main/java/au/org/ala/names/search/DwcaNameIndexer.java
@@ -574,7 +574,16 @@ public class DwcaNameIndexer extends ALANameIndexer {
         String nameComplete = doc.get(NameIndexField.NAME_COMPLETE.toString());
         String lsid = doc.get(NameIndexField.LSID.toString());
         //get the canonical version if the sciname
-        String cname = getCanonical(name);
+        String cname = name;
+        ParsedName pn = null;
+        try {
+            pn = parser.parse(name);
+            if(pn.isParsableType()){
+                cname = pn.canonicalName();
+            }
+        } catch(Exception e){
+            //do nothing
+        }
         //create a new classification for this entry based on the parent
         LinnaeanRankClassification newcl = new LinnaeanRankClassification(higherClass);
         switch(rankId){
@@ -605,6 +614,9 @@ public class DwcaNameIndexer extends ALANameIndexer {
             case 7000:
                 newcl.setSpecies(cname);
                 newcl.setSid(lsid);
+                if (pn != null && pn.isParsableType()) {
+                    newcl.setSpecificEpithet(pn.getSpecificEpithet());
+                }
                 break;
         }
         while (children != null && children.scoreDocs.length > 0) {
@@ -675,23 +687,6 @@ public class DwcaNameIndexer extends ALANameIndexer {
         if (rankId >= 0 && rankId % 1000 == 0)
             boost *= 5.0f;
         return boost;
-    }
-
-    /**
-     *
-     * @param name
-     * @return The canonical form of the supplied name.
-     */
-    private String getCanonical(String name){
-        try {
-            ParsedName pn = parser.parse(name);
-            if(pn.isParsableType()){
-                return pn.canonicalName();
-            }
-        } catch(Exception e){
-            //do nothing
-        }
-        return name;
     }
 
     /**

--- a/src/main/resources/au/org/ala/names/index/nomenclatural_codes.csv
+++ b/src/main/resources/au/org/ala/names/index/nomenclatural_codes.csv
@@ -1,4 +1,5 @@
 acronym,NomenclaturalCode,title,link
+ICN,BOTANICAL,International Code of Nomenclature for algae, fungi, and plants,http://www.iapt-taxon.org/nomen/main.php
 ICNAFP,BOTANICAL,International Code of Nomenclature for algae, fungi, and plants,http://www.iapt-taxon.org/nomen/main.php
 ICVN,VIRUS,Variant of ICVCN,https://talk.ictvonline.org/
 NCGN,BACTERIAL,Incorrect code for Prokaryota,

--- a/src/test/java/au/org/ala/names/index/ALANameAnalyserTest.java
+++ b/src/test/java/au/org/ala/names/index/ALANameAnalyserTest.java
@@ -132,6 +132,42 @@ public class ALANameAnalyserTest {
     }
 
     @Test
+    public void testKey14() throws Exception {
+        NameKey key = this.analyser.analyse("ICNAFP", "Munida aff. amathea", null, "species");
+        assertEquals(NomenclaturalCode.BOTANICAL, key.getCode());
+        assertEquals(NameType.DOUBTFUL, key.getType());
+        assertEquals("MUNIDA AFF AMATHEA", key.getScientificName());
+        assertNull(key.getScientificNameAuthorship());
+    }
+
+    @Test
+    public void testKey15() throws Exception {
+        NameKey key = this.analyser.analyse("ICNAFP", "Munida aff amathea", null, "species");
+        assertEquals(NomenclaturalCode.BOTANICAL, key.getCode());
+        assertEquals(NameType.DOUBTFUL, key.getType());
+        assertEquals("MUNIDA AFF AMATHEA", key.getScientificName());
+        assertNull(key.getScientificNameAuthorship());
+    }
+
+    @Test
+    public void testKey16() throws Exception {
+        NameKey key = this.analyser.analyse("ICNAFP", "Waminoa cf. brickneri", null, "species");
+        assertEquals(NomenclaturalCode.BOTANICAL, key.getCode());
+        assertEquals(NameType.DOUBTFUL, key.getType());
+        assertEquals("WAMINOA CF BRICKNERI", key.getScientificName());
+        assertNull(key.getScientificNameAuthorship());
+    }
+
+    @Test
+    public void testKey17() throws Exception {
+        NameKey key = this.analyser.analyse(NomenclaturalCode.BOTANICAL, "Waminoa cf. brickneri", null, null, true);
+        assertEquals(NomenclaturalCode.BOTANICAL, key.getCode());
+        assertEquals(NameType.DOUBTFUL, key.getType());
+        assertEquals("WAMINOA CF BRICKNERI", key.getScientificName());
+        assertNull(key.getScientificNameAuthorship());
+    }
+
+    @Test
     public void testAuthorEquals1() throws Exception {
         assertEquals(0, this.analyser.compareAuthor(null, null));
         assertTrue( this.analyser.compareAuthor("L.", null) > 0);

--- a/src/test/java/au/org/ala/names/index/ALANameAnalyserTest.java
+++ b/src/test/java/au/org/ala/names/index/ALANameAnalyserTest.java
@@ -160,7 +160,7 @@ public class ALANameAnalyserTest {
 
     @Test
     public void testKey17() throws Exception {
-        NameKey key = this.analyser.analyse(NomenclaturalCode.BOTANICAL, "Waminoa cf. brickneri", null, null, true);
+        NameKey key = this.analyser.analyse(NomenclaturalCode.BOTANICAL, "Waminoa cf. brickneri", null, null, null, true);
         assertEquals(NomenclaturalCode.BOTANICAL, key.getCode());
         assertEquals(NameType.DOUBTFUL, key.getType());
         assertEquals("WAMINOA CF BRICKNERI", key.getScientificName());
@@ -190,8 +190,8 @@ public class ALANameAnalyserTest {
 
     @Test
     public void testKeyEquals1() throws Exception {
-        NameKey key1 = this.analyser.analyse(NomenclaturalCode.BOTANICAL, "Hemigenia brachyphylla F.Muell.", null, RankType.SPECIES, true);
-        NameKey key2 = this.analyser.analyse(NomenclaturalCode.BOTANICAL, "Hemigenia brachyphylla F.Mueller", null, RankType.SPECIES, true);
+        NameKey key1 = this.analyser.analyse(NomenclaturalCode.BOTANICAL, "Hemigenia brachyphylla F.Muell.", null, RankType.SPECIES, null, true);
+        NameKey key2 = this.analyser.analyse(NomenclaturalCode.BOTANICAL, "Hemigenia brachyphylla F.Mueller", null, RankType.SPECIES, null, true);
         assertTrue(key1.equals(key2));
     }
 
@@ -261,8 +261,8 @@ public class ALANameAnalyserTest {
     // Loose names
     @Test
     public void testkeyEquals11() throws Exception {
-        NameKey key1 = this.analyser.analyse(null, "Acaena rorida", "B.H.Macmill.", RankType.SPECIES, false);
-        NameKey key2 = this.analyser.analyse(null, "Acaena rorida B.H.Macmill.", null, null, true);
+        NameKey key1 = this.analyser.analyse(null, "Acaena rorida", "B.H.Macmill.", RankType.SPECIES, null, false);
+        NameKey key2 = this.analyser.analyse(null, "Acaena rorida B.H.Macmill.", null, null, null, true);
         assertTrue(key1.equals(key2));
     }
 
@@ -295,11 +295,27 @@ public class ALANameAnalyserTest {
         NameKey key2 = this.analyser.analyse("ICNAFP", "Hemigenia brachyphylla", "A.F. Nurke", "species");
         assertTrue(key1.equals(key2));
     }
+
     @Test
     public void testKeyEquals16() throws Exception {
         NameKey key1 = this.analyser.analyse("ICNAFP", "Hemigenia brachyphylla", "A. Nurke", "species");
         NameKey key2 = this.analyser.analyse("ICNAFP", "Hemigenia brachyphylla", "A Nurke", "species");
         assertTrue(key1.equals(key2));
+    }
+
+    // Placeholder names
+    @Test
+    public void testKeyEquals17() throws Exception {
+        NameKey key1 = this.analyser.analyse(NomenclaturalCode.BOTANICAL, "Incertae sedis", "F.Muell.", RankType.SPECIES, TaxonomicType.ACCEPTED, false);
+        NameKey key2 = this.analyser.analyse(NomenclaturalCode.BOTANICAL, "Incertae sedis", "F.Muell.", RankType.SPECIES, TaxonomicType.ACCEPTED, false);
+        assertFalse(key1.equals(key2));
+    }
+
+    @Test
+    public void testKeyEquals18() throws Exception {
+        NameKey key1 = this.analyser.analyse(NomenclaturalCode.BOTANICAL, "Hemigenia brachyphylla", "F.Muell.", RankType.SPECIES, TaxonomicType.INCERTAE_SEDIS, false);
+        NameKey key2 = this.analyser.analyse(NomenclaturalCode.BOTANICAL, "Hemigenia brachyphylla", "F.Muell.", RankType.SPECIES, TaxonomicType.INCERTAE_SEDIS, false);
+        assertFalse(key1.equals(key2));
     }
 
 

--- a/src/test/java/au/org/ala/names/index/ALANameAnalyserTest.java
+++ b/src/test/java/au/org/ala/names/index/ALANameAnalyserTest.java
@@ -261,7 +261,7 @@ public class ALANameAnalyserTest {
     // Loose names
     @Test
     public void testkeyEquals11() throws Exception {
-        NameKey key1 = this.analyser.analyse(null, "Acaena rorida", "B.H.Macmill.", RankType.SPECIES, null, false);
+        NameKey key1 = this.analyser.analyse(null, "Acaena rorida", "B.H.Macmill.", null, null, false);
         NameKey key2 = this.analyser.analyse(null, "Acaena rorida B.H.Macmill.", null, null, null, true);
         assertTrue(key1.equals(key2));
     }

--- a/src/test/java/au/org/ala/names/index/ALATaxonResolverTest.java
+++ b/src/test/java/au/org/ala/names/index/ALATaxonResolverTest.java
@@ -5,11 +5,11 @@ import org.gbif.dwc.terms.DwcTerm;
 import org.junit.After;
 import org.junit.Test;
 
+import java.io.File;
 import java.util.Arrays;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.*;
 
 /**
  * File description.
@@ -267,6 +267,32 @@ public class ALATaxonResolverTest extends TestUtils {
         assertEquals(tcia, resolution.getResolved(tcia));
         assertEquals(tcia, resolution.getResolved(tcin));
         assertEquals(tcia, resolution.getResolved(tcim));
+    }
+
+    // Ensure psuedo taxa are included and get resolved
+    @Test
+    public void testResolution5() throws Exception {
+        TaxonomyConfiguration config = TaxonomyConfiguration.read(this.resourceReader("taxonomy-config-2.json"));
+        this.taxonomy = new Taxonomy(config, null);
+        this.taxonomy.begin();
+        DwcaNameSource source = new DwcaNameSource(new File(this.getClass().getResource("dwca-1").getFile()));
+        this.taxonomy.load(Arrays.asList(source));
+        this.taxonomy.resolveLinks();
+        TaxonConceptInstance tci1 = this.taxonomy.getInstance("urn:lsid:biodiversity.org.au:afd.taxon:c2056f1b-fcde-45b9-904b-1cab280368d1");
+        TaxonConceptInstance tci2 = this.taxonomy.getInstance("ALA_Canis_lupus_dingo");
+        TaxonConcept tc1 = tci1.getContainer();
+        TaxonConcept tc2 = tci2.getContainer();
+        assertEquals(1, tc1.getInstances().size());
+        assertEquals(2, tc2.getInstances().size());
+        ALATaxonResolver resolver = new ALATaxonResolver(taxonomy);
+        TaxonResolution resolution = resolver.resolve(tc2, resolver.principals(tc2, tc2.getInstances()), tc2.getInstances());
+        assertEquals(1, resolution.getUsed().size());
+        assertEquals(1, resolution.getPrincipal().size());
+        TaxonConceptInstance tci3 = resolution.getPrincipal().get(0);
+        assertFalse(tci3.isOutput());
+        assertNotSame(tci2, tci3);
+        assertSame(tci3, resolution.getResolved(tci2));
+        assertSame(tci3, resolution.getResolved(tci3));
     }
 
 }

--- a/src/test/java/au/org/ala/names/index/ALATaxonResolverTest.java
+++ b/src/test/java/au/org/ala/names/index/ALATaxonResolverTest.java
@@ -244,4 +244,29 @@ public class ALATaxonResolverTest extends TestUtils {
     }
 
 
+    // Ensure unplaced taxa are linked with accepted taxa
+    @Test
+    public void testResolution4() throws Exception {
+        TaxonomyConfiguration config = TaxonomyConfiguration.read(this.resourceReader("taxonomy-config-2.json"));
+        this.taxonomy = new Taxonomy(config, null);
+        this.taxonomy.begin();
+        CSVNameSource source = new CSVNameSource(this.resourceReader("taxonomy-26.csv"), DwcTerm.Taxon);
+        this.taxonomy.load(Arrays.asList(source));
+        this.taxonomy.resolveLinks();
+        TaxonConceptInstance tcia = this.taxonomy.getInstance("http://id.biodiversity.org.au/node/apni/50587232");
+        TaxonConceptInstance tcin = this.taxonomy.getInstance("NZOR-6-60501");
+        TaxonConceptInstance tcim = this.taxonomy.getInstance("http://id.biodiversity.org.au/name/ausmoss/10001168");
+        TaxonConcept tca = tcia.getContainer();
+        assertEquals(3, tca.getInstances().size());
+        assertEquals(tca, tcin.getContainer());
+        assertEquals(tca, tcim.getContainer());
+        ALATaxonResolver resolver = new ALATaxonResolver(taxonomy);
+        TaxonResolution resolution = resolver.resolve(tca, resolver.principals(tca, tca.getInstances()), tca.getInstances());
+        assertEquals(1, resolution.getUsed().size());
+        assertEquals(1, resolution.getPrincipal().size());
+        assertEquals(tcia, resolution.getResolved(tcia));
+        assertEquals(tcia, resolution.getResolved(tcin));
+        assertEquals(tcia, resolution.getResolved(tcim));
+    }
+
 }

--- a/src/test/java/au/org/ala/names/index/ScientificNameTest.java
+++ b/src/test/java/au/org/ala/names/index/ScientificNameTest.java
@@ -59,7 +59,7 @@ public class ScientificNameTest {
                 null,
                 null
         );
-        NameKey instanceKey = this.analyser.analyse(NomenclaturalCode.ZOOLOGICAL, NAME_1, AUTHOR_1, RankType.SPECIES, false);
+        NameKey instanceKey = this.analyser.analyse(NomenclaturalCode.ZOOLOGICAL, NAME_1, AUTHOR_1, RankType.SPECIES, null, false);
         NameKey nameKey = instanceKey.toNameKey();
         ScientificName name = new ScientificName(null, nameKey);
         name.addInstance(instanceKey, instance);

--- a/src/test/java/au/org/ala/names/index/TaxonConceptTest.java
+++ b/src/test/java/au/org/ala/names/index/TaxonConceptTest.java
@@ -55,7 +55,7 @@ public class TaxonConceptTest {
                 null,
                 null
         );
-        NameKey instanceKey = this.analyser.analyse(NomenclaturalCode.ZOOLOGICAL, NAME_1, AUTHOR_1, RankType.SPECIES, false);
+        NameKey instanceKey = this.analyser.analyse(NomenclaturalCode.ZOOLOGICAL, NAME_1, AUTHOR_1, RankType.SPECIES, null, false);
         NameKey nameKey = instanceKey.toNameKey();
         ScientificName name = new ScientificName(null, nameKey);
         TaxonConcept concept = new TaxonConcept(name, nameKey);

--- a/src/test/java/au/org/ala/names/index/TaxonomyTest.java
+++ b/src/test/java/au/org/ala/names/index/TaxonomyTest.java
@@ -353,6 +353,62 @@ public class TaxonomyTest extends TestUtils {
         TaxonConcept tcSyn2 = syn2.getContainer();
         assertSame(tcAcc1, tcAcc2);
         assertSame(tcSyn1, tcSyn2);
+        assertEquals(RankType.UNRANKED, syn1.getRank());
+        assertEquals(RankType.UNRANKED, syn2.getRank());
+        assertNull(syn1.getProvenance());
+        assertNull(syn2.getProvenance());
+    }
+
+    // Test resolution to a preferred taxon for an unranked synonym which should stay unranked
+    @Test
+    public void testResolveUnranked6() throws Exception {
+        TaxonomyConfiguration config = TaxonomyConfiguration.read(this.resourceReader("taxonomy-config-2.json"));
+        this.taxonomy = new Taxonomy(config, null);
+        this.taxonomy.begin();
+        CSVNameSource source1 = new CSVNameSource(this.resourceReader("taxonomy-24.csv"), DwcTerm.Taxon);
+        this.taxonomy.load(Arrays.asList(source1));
+        this.taxonomy.resolve();
+        TaxonConceptInstance acc1 = this.taxonomy.getInstance("Accepted-1");
+        TaxonConceptInstance acc2 = this.taxonomy.getInstance("Accepted-2");
+        TaxonConceptInstance syn1 = this.taxonomy.getInstance("Synonym-1");
+        assertNotNull(acc1);
+        assertNotNull(acc2);
+        assertNotNull(syn1);
+        TaxonConcept tcAcc1 = acc1.getContainer();
+        TaxonConcept tcAcc2 = acc2.getContainer();
+        TaxonConcept tcSyn1 = syn1.getContainer();
+        assertSame(tcAcc1, tcAcc2);
+        assertSame(acc1, syn1.getAccepted());
+        assertEquals(RankType.SUBSPECIES, acc1.getRank());
+        assertEquals(RankType.SUBSPECIES, acc2.getRank());
+        assertEquals(RankType.UNRANKED, syn1.getRank());
+        assertNull(syn1.getProvenance());
+    }
+    @Test
+    public void testResolveUnranked7() throws Exception {
+        TaxonomyConfiguration config = TaxonomyConfiguration.read(this.resourceReader("taxonomy-config-2.json"));
+        this.taxonomy = new Taxonomy(config, null);
+        this.taxonomy.begin();
+        CSVNameSource source1 = new CSVNameSource(this.resourceReader("taxonomy-25.csv"), DwcTerm.Taxon);
+        this.taxonomy.load(Arrays.asList(source1));
+        this.taxonomy.resolve();
+        TaxonConceptInstance acc1 = this.taxonomy.getInstance("Accepted-1");
+        TaxonConceptInstance acc2 = this.taxonomy.getInstance("Accepted-2");
+        TaxonConceptInstance syn1 = this.taxonomy.getInstance("Synonym-1");
+        TaxonConceptInstance syn2 = this.taxonomy.getInstance("Synonym-2");
+        assertNotNull(acc1);
+        assertNotNull(acc2);
+        assertNotNull(syn1);
+        assertNotNull(syn2);
+        TaxonConcept tcAcc1 = acc1.getContainer();
+        TaxonConcept tcAcc2 = acc2.getContainer();
+        TaxonConcept tcSyn1 = syn1.getContainer();
+        TaxonConcept tcSyn2 = syn2.getContainer();
+        assertSame(tcAcc1, tcAcc2);
+        assertSame(tcSyn1, tcSyn2);
+        assertEquals(RankType.VARIETY, syn1.getRank());
+        assertEquals(RankType.UNRANKED, syn2.getRank());
+        assertFalse(syn1.getProvenance() == null || syn1.getProvenance().isEmpty());
     }
 
     // Test placement on an uncoded name
@@ -402,7 +458,7 @@ public class TaxonomyTest extends TestUtils {
         assertEquals(12, this.rowCount(new File(dir, "taxon.txt")));
         assertEquals(22, this.rowCount(new File(dir, "taxonvariant.txt")));
         assertEquals(52, this.rowCount(new File(dir, "identifier.txt")));
-        assertEquals(12, this.rowCount(new File(dir, "rightsholder.txt")));
+        assertEquals(13, this.rowCount(new File(dir, "rightsholder.txt")));
 
     }
 
@@ -423,7 +479,7 @@ public class TaxonomyTest extends TestUtils {
         assertEquals(5, this.rowCount(new File(dir, "taxon.txt")));
         assertEquals(6, this.rowCount(new File(dir, "taxonvariant.txt")));
         assertEquals(6, this.rowCount(new File(dir, "identifier.txt")));
-        assertEquals(13, this.rowCount(new File(dir, "rightsholder.txt")));
+        assertEquals(14, this.rowCount(new File(dir, "rightsholder.txt")));
     }
 
 
@@ -573,7 +629,7 @@ public class TaxonomyTest extends TestUtils {
         assertEquals(6, this.rowCount(new File(dir, "taxon.txt")));
         assertEquals(11, this.rowCount(new File(dir, "taxonvariant.txt")));
         assertEquals(11, this.rowCount(new File(dir, "identifier.txt")));
-        assertEquals(12, this.rowCount(new File(dir, "rightsholder.txt")));
+        assertEquals(13, this.rowCount(new File(dir, "rightsholder.txt")));
     }
 
     // Test the presence of a taxon loop

--- a/src/test/java/au/org/ala/names/index/provider/KeyAdjusterTest.java
+++ b/src/test/java/au/org/ala/names/index/provider/KeyAdjusterTest.java
@@ -42,7 +42,7 @@ public class KeyAdjusterTest extends TestUtils {
     @Test
     public void testAdjust1() {
         TaxonConceptInstance instance = this.createInstance("ID-1", NomenclaturalCode.ZOOLOGICAL, "Osphranter rufus", this.provider, TaxonomicType.ACCEPTED );
-        NameKey key = this.analyser.analyse(instance.getCode(), instance.getScientificName(), instance.getScientificNameAuthorship(), instance.getRank(), false);
+        NameKey key = this.analyser.analyse(instance.getCode(), instance.getScientificName(), instance.getScientificNameAuthorship(), instance.getRank(), null, false);
         NameKey key2 = this.adjuster.adjustKey(key, instance);
         assertSame(key, key2);
     }
@@ -50,7 +50,7 @@ public class KeyAdjusterTest extends TestUtils {
     @Test
     public void testAdjust2() {
         TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalCode.BOTANICAL, NomenclaturalCode.BOTANICAL.getAcronym(), this.provider,"Acacia dealbata", "Link.", null, TaxonomicType.MISAPPLIED, TaxonomicType.MISAPPLIED.getTerm(), RankType.SPECIES,  RankType.SPECIES.getRank(), null, null,null, null, null, null, null, null, null, null);
-        NameKey key = this.analyser.analyse(instance.getCode(), instance.getScientificName(), instance.getScientificNameAuthorship(), instance.getRank(), false);
+        NameKey key = this.analyser.analyse(instance.getCode(), instance.getScientificName(), instance.getScientificNameAuthorship(), instance.getRank(), null, false);
         NameKey key2 = this.adjuster.adjustKey(key, instance);
         assertSame(key, key2);
     }
@@ -58,7 +58,7 @@ public class KeyAdjusterTest extends TestUtils {
     @Test
     public void testAdjust3() {
         TaxonConceptInstance instance = this.createInstance("ID-1", NomenclaturalCode.VIRUS, "Viruses", this.provider, TaxonomicType.ACCEPTED );
-        NameKey key = this.analyser.analyse(instance.getCode(), instance.getScientificName(), instance.getScientificNameAuthorship(), instance.getRank(), false);
+        NameKey key = this.analyser.analyse(instance.getCode(), instance.getScientificName(), instance.getScientificNameAuthorship(), instance.getRank(), null, false);
         NameKey key2 = this.adjuster.adjustKey(key, instance);
         assertNotSame(key, key2);
         assertEquals(key.getCode(), key2.getCode());
@@ -71,7 +71,7 @@ public class KeyAdjusterTest extends TestUtils {
     @Test
     public void testAdjust4() {
         TaxonConceptInstance instance = this.createInstance("ID-1", NomenclaturalCode.PHYLOCODE, "Viruses", this.provider, TaxonomicType.MISAPPLIED );
-        NameKey key = this.analyser.analyse(instance.getCode(), instance.getScientificName(), instance.getScientificNameAuthorship(), instance.getRank(), false);
+        NameKey key = this.analyser.analyse(instance.getCode(), instance.getScientificName(), instance.getScientificNameAuthorship(), instance.getRank(), null, false);
         NameKey key2 = this.adjuster.adjustKey(key, instance);
         assertNotSame(key, key2);
         assertEquals(NomenclaturalCode.BACTERIAL, key2.getCode());
@@ -84,7 +84,7 @@ public class KeyAdjusterTest extends TestUtils {
     @Test
     public void testAdjust5() {
         TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalCode.PHYLOCODE, NomenclaturalCode.PHYLOCODE.getAcronym(), this.provider,"Acacia dealbata", "Link.", null, TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES,  RankType.SPECIES.getRank(), null, null,null, null, null, null, null, null, null, null);
-        NameKey key = this.analyser.analyse(instance.getCode(), instance.getScientificName(), instance.getScientificNameAuthorship(), instance.getRank(), false);
+        NameKey key = this.analyser.analyse(instance.getCode(), instance.getScientificName(), instance.getScientificNameAuthorship(), instance.getRank(), null, false);
         NameKey key2 = this.adjuster.adjustKey(key, instance);
         assertNotSame(key, key2);
         assertEquals(NomenclaturalCode.BACTERIAL, key2.getCode());
@@ -98,7 +98,7 @@ public class KeyAdjusterTest extends TestUtils {
     @Test
     public void testAdjust6() {
         TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalCode.BOTANICAL, NomenclaturalCode.BOTANICAL.getAcronym(), this.provider,"Acacia dealbata", "Link.", null, TaxonomicType.MISAPPLIED, TaxonomicType.MISAPPLIED.getTerm(), RankType.DOMAIN,  RankType.DOMAIN.getRank(), null, null,null, null, null, null, null, null, null, null);
-        NameKey key = this.analyser.analyse(instance.getCode(), instance.getScientificName(), instance.getScientificNameAuthorship(), instance.getRank(), false);
+        NameKey key = this.analyser.analyse(instance.getCode(), instance.getScientificName(), instance.getScientificNameAuthorship(), instance.getRank(), null, false);
         NameKey key2 = this.adjuster.adjustKey(key, instance);
         assertNotSame(key, key2);
         assertEquals(NomenclaturalCode.CULTIVARS, key2.getCode());

--- a/src/test/java/au/org/ala/names/search/ALANameSearcherTest.java
+++ b/src/test/java/au/org/ala/names/search/ALANameSearcherTest.java
@@ -1361,11 +1361,11 @@ public class ALANameSearcherTest {
     @Test
     public void testSimpleLookup10()  {
         try {
-            String name = "Neobatrachus sudelli";
+            String name = "Eucalyptus acaciaeformis";
             NameSearchResult nsr = searcher.searchForRecord(name);
             assertNotNull(nsr);
-            assertNull(nsr.getAcceptedLsid());
-            assertEquals("ALA_Neobatrachus_sudelli", nsr.getLsid());
+            assertNotNull(nsr.getAcceptedLsid());
+            assertEquals("http://id.biodiversity.org.au/node/apni/2889217", nsr.getAcceptedLsid());
           } catch (SearchResultException ex) {
             fail("Unexpected search exception " + ex);
         }

--- a/src/test/java/au/org/ala/names/search/ALANameSearcherTest.java
+++ b/src/test/java/au/org/ala/names/search/ALANameSearcherTest.java
@@ -1369,23 +1369,6 @@ public class ALANameSearcherTest {
     }
 
 
-    @Ignore // TODO Find valid parent-child synonym
-    @Test
-    public void testSimpleLookup11()  {
-        try {
-            String name = "Pimelea collina";
-            NameSearchResult nsr = searcher.searchForRecord(name);
-            fail("Expecting parent-child synonym exception");
-        } catch (ParentSynonymChildException ex) {
-            NameSearchResult nsr = ex.getChildResult();
-            assertNotNull(nsr);
-            assertEquals("urn:lsid:biodiversity.org.au:afd.taxon:6667178a-4c9c-475d-938b-7f9733707588", nsr.getLsid());
-            assertEquals(RankType.SUBSPECIES, nsr.getRank());
-        } catch (SearchResultException ex) {
-            fail("Unexpected search exception " + ex);
-        }
-    }
-
     @Test
     public void testSimpleLookup12()  {
         try {
@@ -1395,6 +1378,38 @@ public class ALANameSearcherTest {
         } catch (HomonymException e) {
         } catch (SearchResultException e) {
             fail("Unexpected search exception " + e);
+        }
+    }
+    @Test
+    public void testParentChildSynonym1()  {
+        try {
+            String name = "Pitta versicolor";
+            NameSearchResult nsr = searcher.searchForRecord(name);
+            fail("Expecting parent-child synonym exception");
+        } catch (ParentSynonymChildException ex) {
+            NameSearchResult nsr = ex.getChildResult();
+            assertNotNull(nsr);
+            assertEquals("urn:lsid:biodiversity.org.au:afd.taxon:d0e66526-1cdd-4b03-85b2-71b7e7d8b84a", nsr.getLsid());
+            assertEquals(RankType.SUBSPECIES, nsr.getRank());
+        } catch (SearchResultException ex) {
+            fail("Unexpected search exception " + ex);
+        }
+    }
+
+    // Top be corrected
+    @Test
+    public void testParentChildSynonym2()  {
+        try {
+            String name = "Diaporthe Nitschke 1870";
+            NameSearchResult nsr = searcher.searchForRecord(name);
+            fail("Expecting parent-child synonym exception");
+        } catch (ParentSynonymChildException ex) {
+            NameSearchResult nsr = ex.getChildResult();
+            assertNotNull(nsr);
+            assertEquals("NZOR-4-95452", nsr.getLsid());
+            assertEquals(RankType.SPECIES, nsr.getRank());
+        } catch (SearchResultException ex) {
+            fail("Unexpected search exception " + ex);
         }
     }
 

--- a/src/test/java/au/org/ala/names/search/ALANameSearcherTest.java
+++ b/src/test/java/au/org/ala/names/search/ALANameSearcherTest.java
@@ -22,7 +22,7 @@ public class ALANameSearcherTest {
     @org.junit.BeforeClass
     public static void init() {
         try {
-            searcher = new ALANameSearcher("/data/lucene/namematching-20170927");
+            searcher = new ALANameSearcher("/data/lucene/namematching-20181105");
         } catch (Exception e) {
             e.printStackTrace();
         }
@@ -36,7 +36,7 @@ public class ALANameSearcherTest {
             fail("A misapplied exception should be thrown");
             //assertEquals("urn:lsid:biodiversity.org.au:apni.taxon:549612",lsid);
         } catch (MisappliedException ex) {
-            assertEquals("NZOR-4-116704", ex.getMatchedResult().getLsid());
+            assertEquals("NZOR-6-119236", ex.getMatchedResult().getLsid());
             //assertNull(ex.getMisappliedResult());
         } catch (Exception ex) {
             fail("No other exceptions should occur, got " + ex);
@@ -78,7 +78,7 @@ public class ALANameSearcherTest {
             fail("Expecting misapplied exception");
             assertNotNull(nsr);
         } catch (MisappliedException ex) {
-            assertEquals("690bcf05-149f-4ab9-82c0-a2746e4d0bcb", ex.getMatchedResult().getLsid());
+            assertEquals("92a4e5c4-32c1-44c6-a9f7-410659692dfa", ex.getMatchedResult().getLsid());
         } catch (SearchResultException ex) {
             fail("Unexpected search exception " + ex);
         }
@@ -87,7 +87,7 @@ public class ALANameSearcherTest {
     @Test
     public void testSynonymAsHomonym1() {
         try {
-            String lsid = searcher.searchForLSID("Terebratella");
+            String lsid = searcher.searchForLSID("Abelia");
             fail("This test should throw a homonym for a matched synonym");
         } catch (HomonymException ex) {
             // Correct behaviour
@@ -196,7 +196,7 @@ public class ALANameSearcherTest {
         } catch (Exception e) {
             assertTrue(e instanceof ExcludedNameException);
             ExcludedNameException ene = (ExcludedNameException) e;
-            assertEquals("urn:lsid:biodiversity.org.au:afd.name:bd492275-e497-4ee3-8bdf-5e1dcab950a3", ene.getExcludedName().getLsid());
+            assertEquals("urn:lsid:biodiversity.org.au:afd.name:4b4fb3db-2bc4-4005-8660-7531a86b8786", ene.getExcludedName().getLsid());
         }
 
         String apcExcludedName = "Parestia elegans";
@@ -328,7 +328,7 @@ public class ALANameSearcherTest {
             String name = "Aplonis fusca hulliana";
             NameSearchResult nsr = searcher.searchForRecord(name, null);
             assertNotNull(nsr);
-            assertEquals("urn:lsid:biodiversity.org.au:afd.taxon:76925a5b-be3b-4e5d-b800-9e3a555b8800", nsr.getLsid());
+            assertEquals("urn:lsid:biodiversity.org.au:afd.taxon:d1674a33-af14-4592-be4d-2ededc1b53cd", nsr.getLsid());
         } catch (SearchResultException ex) {
             fail("Not expecting exception " + ex);
         }
@@ -340,7 +340,7 @@ public class ALANameSearcherTest {
             String name = "Cryphaea tenella";
             NameSearchResult nsr = searcher.searchForRecord(name, null);
             assertNotNull(nsr);
-            assertEquals("http://id.biodiversity.org.au/node/ausmoss/10044838", nsr.getLsid());
+            assertEquals("http://id.biodiversity.org.au/node/ausmoss/10068952", nsr.getLsid());
             assertEquals(name, nsr.getRankClassification().getScientificName());
         } catch (SearchResultException ex) {
             fail("Not expecting exception " + ex);
@@ -633,7 +633,7 @@ public class ALANameSearcherTest {
         try {
             NameSearchResult nsr = searcher.searchForRecord(name, null, true);
             assertNotNull(nsr);
-            assertEquals("urn:lsid:biodiversity.org.au:afd.taxon:10fdfc12-a6d2-42ea-b9fa-2492cf78b0dc", nsr.getLsid());
+            assertEquals("urn:lsid:biodiversity.org.au:afd.taxon:b1ba5449-a68e-4c3b-ae90-8e667617945b", nsr.getLsid());
             assertEquals(MatchType.EXACT, nsr.getMatchType());
         } catch (SearchResultException ex) {
             fail("Unexpected search exception " + ex.getMessage());
@@ -646,7 +646,7 @@ public class ALANameSearcherTest {
         try {
             NameSearchResult nsr = searcher.searchForRecord(name, null, true);
             assertNotNull(nsr);
-            assertEquals("urn:lsid:biodiversity.org.au:afd.taxon:10fdfc12-a6d2-42ea-b9fa-2492cf78b0dc", nsr.getLsid());
+            assertEquals("urn:lsid:biodiversity.org.au:afd.taxon:b1ba5449-a68e-4c3b-ae90-8e667617945b", nsr.getLsid());
             assertEquals(MatchType.SOUNDEX, nsr.getMatchType());
         } catch (SearchResultException ex) {
             fail("Unexpected search exception " + ex.getMessage());
@@ -659,7 +659,8 @@ public class ALANameSearcherTest {
         try {
             NameSearchResult nsr = searcher.searchForRecord(name, null, true);
             assertNotNull(nsr);
-            assertEquals("urn:lsid:biodiversity.org.au:afd.name:b64aac6e-d2c4-40d0-b3fd-2b037a6e4d07", nsr.getLsid());
+            assertEquals("CAAB:79629da1:6054320e:589caaa6:bb265593", nsr.getLsid());
+            assertEquals("urn:lsid:biodiversity.org.au:afd.taxon:3fb329bb-89d6-4589-b98a-3b1a6a284021", nsr.getAcceptedLsid());
             assertEquals(MatchType.SOUNDEX, nsr.getMatchType());
         } catch (SearchResultException ex) {
             fail("Unexpected search exception " + ex.getMessage());
@@ -793,7 +794,7 @@ public class ALANameSearcherTest {
             String lsid = searcher.searchForLSID("Animalia");
             assertEquals("urn:lsid:biodiversity.org.au:afd.taxon:4647863b-760d-4b59-aaa1-502c8cdf8d3c", lsid);
             lsid = searcher.searchForLSID("Bacteria");
-            assertEquals("NZOR-4-71604", lsid);
+            assertEquals("NZOR-6-73174", lsid);
         } catch (SearchResultException e) {
             e.printStackTrace();
             fail("testNoRank failed");
@@ -875,7 +876,7 @@ public class ALANameSearcherTest {
             cl.setGenus("Agathis");
             cl.setKingdom("Animalia");
             NameSearchResult nsr = searcher.searchForRecord(cl.getScientificName(), cl, null, true, true);
-            assertEquals("urn:lsid:biodiversity.org.au:afd.taxon:d12e8168-51ae-4883-8c93-3ce60af18f15", nsr.getLsid());
+            assertEquals("urn:lsid:biodiversity.org.au:afd.taxon:fa8687aa-2d6f-4d86-b9b7-175cb32136d3", nsr.getLsid());
         } catch (Exception e) {
             fail("A kingdom was supplied and should be resolvable. " + e.getMessage());
         }
@@ -1092,7 +1093,7 @@ public class ALANameSearcherTest {
     public void testSearchForLSID1() {
         try {
             String lsid = searcher.searchForLSID("Anochetus");
-            assertEquals("urn:lsid:biodiversity.org.au:afd.taxon:d9d200f2-8f7e-4b71-8a79-6dd5df92f843", lsid);
+            assertEquals("urn:lsid:biodiversity.org.au:afd.taxon:bea6dc0a-1e16-424d-9256-4b01e5a56b05", lsid);
         } catch (SearchResultException ex) {
             fail("Unexpected search exception " + ex.getMessage());
         }
@@ -1102,7 +1103,7 @@ public class ALANameSearcherTest {
     public void testSearchForLSID2() {
         try {
             String lsid = searcher.searchForLSID("Anochetus", true);
-            assertEquals("urn:lsid:biodiversity.org.au:afd.taxon:d9d200f2-8f7e-4b71-8a79-6dd5df92f843", lsid);
+            assertEquals("urn:lsid:biodiversity.org.au:afd.taxon:bea6dc0a-1e16-424d-9256-4b01e5a56b05", lsid);
         } catch (SearchResultException ex) {
             fail("Unexpected search exception " + ex.getMessage());
         }
@@ -1112,7 +1113,7 @@ public class ALANameSearcherTest {
     public void testSearchForLSID3() {
         try {
             String lsid = searcher.searchForLSID("Anochetus", true);
-            assertEquals("urn:lsid:biodiversity.org.au:afd.taxon:d9d200f2-8f7e-4b71-8a79-6dd5df92f843", lsid);
+            assertEquals("urn:lsid:biodiversity.org.au:afd.taxon:bea6dc0a-1e16-424d-9256-4b01e5a56b05", lsid);
         } catch (SearchResultException ex) {
             fail("Unexpected search exception " + ex.getMessage());
         }
@@ -1122,7 +1123,7 @@ public class ALANameSearcherTest {
     public void testSearchForLSID4() {
         try {
             String lsid = searcher.searchForLSID("Anochetus", RankType.GENUS);
-            assertEquals("urn:lsid:biodiversity.org.au:afd.taxon:d9d200f2-8f7e-4b71-8a79-6dd5df92f843", lsid);
+            assertEquals("urn:lsid:biodiversity.org.au:afd.taxon:bea6dc0a-1e16-424d-9256-4b01e5a56b05", lsid);
         } catch (SearchResultException ex) {
             fail("Unexpected search exception " + ex.getMessage());
         }
@@ -1133,7 +1134,7 @@ public class ALANameSearcherTest {
         try {
             LinnaeanRankClassification cl = new LinnaeanRankClassification("Animalia", "Arthropoda", "Insecta", "Hymenoptera", "Formicidae", "Anochetus", null);
             String lsid = searcher.searchForLSID("Anochetus", cl, RankType.GENUS);
-            assertEquals("urn:lsid:biodiversity.org.au:afd.taxon:d9d200f2-8f7e-4b71-8a79-6dd5df92f843", lsid);
+            assertEquals("urn:lsid:biodiversity.org.au:afd.taxon:bea6dc0a-1e16-424d-9256-4b01e5a56b05", lsid);
         } catch (SearchResultException ex) {
             fail("Unexpected search exception " + ex.getMessage());
         }
@@ -1144,7 +1145,7 @@ public class ALANameSearcherTest {
         try {
             LinnaeanRankClassification cl = new LinnaeanRankClassification("Animalia", "Arthropoda", "Insecta", "Hymenoptera", "Formicidae", "Anochetus", null);
             String lsid = searcher.searchForLSID(cl, true);
-            assertEquals("urn:lsid:biodiversity.org.au:afd.taxon:d9d200f2-8f7e-4b71-8a79-6dd5df92f843", lsid);
+            assertEquals("urn:lsid:biodiversity.org.au:afd.taxon:bea6dc0a-1e16-424d-9256-4b01e5a56b05", lsid);
         } catch (SearchResultException ex) {
             fail("Unexpected search exception " + ex.getMessage());
         }
@@ -1155,7 +1156,7 @@ public class ALANameSearcherTest {
         try {
             LinnaeanRankClassification cl = new LinnaeanRankClassification("Animalia", "Arthropoda", "Insecta", "Hymenoptera", "Formicidae", "Anochetus", null);
             String lsid = searcher.searchForLSID(cl, true);
-            assertEquals("urn:lsid:biodiversity.org.au:afd.taxon:d9d200f2-8f7e-4b71-8a79-6dd5df92f843", lsid);
+            assertEquals("urn:lsid:biodiversity.org.au:afd.taxon:bea6dc0a-1e16-424d-9256-4b01e5a56b05", lsid);
         } catch (SearchResultException ex) {
             fail("Unexpected search exception " + ex.getMessage());
         }
@@ -1164,10 +1165,10 @@ public class ALANameSearcherTest {
     @Test
     public void testFuzzyMatches() throws Exception {
         //Eolophus roseicapillus - non fuzzy match
-        assertEquals("urn:lsid:biodiversity.org.au:afd.taxon:90fafac9-81b4-4ed7-e044-00144f3b4a43", searcher.searchForLSID("Deretaphrus illusus"));
+        assertEquals("urn:lsid:biodiversity.org.au:afd.taxon:577ff059-a2a7-48b0-976c-fdd6a345f878", searcher.searchForLSID("Eolophus roseicapilla"));
 
         //Eolophus roseicapilla - fuzzy match
-        assertEquals("urn:lsid:biodiversity.org.au:afd.taxon:90fafac9-81b4-4ed7-e044-00144f3b4a43", searcher.searchForLSID("Deretaphrus illusa", true));
+        assertEquals("urn:lsid:biodiversity.org.au:afd.taxon:577ff059-a2a7-48b0-976c-fdd6a345f878", searcher.searchForLSID("Eolophus roseicapillus", true));
     }
 
     @Test
@@ -1198,9 +1199,9 @@ public class ALANameSearcherTest {
             LinnaeanRankClassification cl = new LinnaeanRankClassification(null, "Opuntia");
             cl.setScientificName("Opuntia spp.");
             searcher.searchForLSID(cl, true);
-            fail("SPP2 failed to throw a homonym exception");
+            fail("SPP2 failed to throw a SPP exception");
         } catch (Exception e) {
-            assertEquals(e.getClass(), HomonymException.class);
+            assertEquals(SPPException.class, e.getClass());
         }
     }
 
@@ -1296,7 +1297,8 @@ public class ALANameSearcherTest {
             cl.setScientificName("Favolus princeps");
             NameSearchResult nsr = searcher.searchForRecord(cl, true);
             assertNotNull(nsr); // Been removed
-            assertEquals("f9db9740-3ce1-4f18-b8f3-9484cadfec5e", nsr.getLsid());
+            assertEquals("43e1bc65-3580-47db-b269-cdb066ed49e9", nsr.getLsid());
+            assertEquals( "10911fd1-a2dd-41f1-9c4d-8dff7f118670", nsr.getAcceptedLsid());
         } catch (SearchResultException ex) {
             fail("Unexpected search exception " + ex);
         }
@@ -1311,7 +1313,7 @@ public class ALANameSearcherTest {
             cl.setScientificName("Andreaea");
             NameSearchResult nsr = searcher.searchForRecord(cl, true);
             assertNotNull(nsr);
-            assertEquals("http://id.biodiversity.org.au/node/ausmoss/10044743", nsr.getLsid());
+            assertEquals("http://id.biodiversity.org.au/node/ausmoss/10057678", nsr.getLsid());
         } catch (SearchResultException ex) {
             fail("Unexpected search exception " + ex);
         }
@@ -1325,7 +1327,7 @@ public class ALANameSearcherTest {
             String name = "Astomum";
             NameSearchResult nsr = searcher.searchForRecord(name, cl, RankType.GENUS);
             assertNotNull(nsr);
-            assertEquals("http://id.biodiversity.org.au/node/ausmoss/10046144", nsr.getLsid());
+            assertEquals("http://id.biodiversity.org.au/name/ausmoss/10001613", nsr.getLsid());
         } catch (SearchResultException ex) {
             fail("Unexpected search exception " + ex);
         }
@@ -1362,7 +1364,8 @@ public class ALANameSearcherTest {
             String name = "Neobatrachus sudelli";
             NameSearchResult nsr = searcher.searchForRecord(name);
             assertNotNull(nsr);
-            assertEquals("urn:lsid:biodiversity.org.au:afd.taxon:953a5af4-2932-4c8b-8f33-850b5f8f3fed", nsr.getAcceptedLsid());
+            assertNull(nsr.getAcceptedLsid());
+            assertEquals("ALA_Neobatrachus_sudelli", nsr.getLsid());
           } catch (SearchResultException ex) {
             fail("Unexpected search exception " + ex);
         }
@@ -1396,18 +1399,17 @@ public class ALANameSearcherTest {
         }
     }
 
-    // Top be corrected
     @Test
     public void testParentChildSynonym2()  {
         try {
-            String name = "Diaporthe Nitschke 1870";
+            String name = "Phoma lobeliae";
             NameSearchResult nsr = searcher.searchForRecord(name);
             fail("Expecting parent-child synonym exception");
         } catch (ParentSynonymChildException ex) {
             NameSearchResult nsr = ex.getChildResult();
             assertNotNull(nsr);
-            assertEquals("NZOR-4-95452", nsr.getLsid());
-            assertEquals(RankType.SPECIES, nsr.getRank());
+            assertEquals("8e64942a-f300-46c8-ba97-76492d25d985", nsr.getLsid());
+            assertEquals(RankType.FORM, nsr.getRank());
         } catch (SearchResultException ex) {
             fail("Unexpected search exception " + ex);
         }
@@ -1422,8 +1424,8 @@ public class ALANameSearcherTest {
             cl.setScientificName(name);
             NameSearchResult nsr = searcher.searchForRecord(cl, true);
             assertNotNull(nsr);
-            assertEquals("urn:lsid:biodiversity.org.au:afd.taxon:b43ac4f1-94ff-4a00-96c3-ed027aa44941", nsr.getAcceptedLsid());
-            assertEquals("Stigmodera aurifera", nsr.getRankClassification().getScientificName());
+            assertEquals("urn:lsid:biodiversity.org.au:afd.taxon:69f365ea-ab45-45a7-97b8-3c8e9241c323", nsr.getAcceptedLsid());
+            assertEquals("Stigmodera (Curis) aurifera", nsr.getRankClassification().getScientificName());
             assertEquals(MatchType.CANONICAL, nsr.getMatchType());
         } catch (SearchResultException e) {
             fail("Unexpected search exception " + e);
@@ -1470,7 +1472,7 @@ public class ALANameSearcherTest {
             cl.setScientificName(name);
             NameSearchResult nsr = searcher.searchForRecord(cl, true);
             assertNotNull(nsr);
-            assertEquals("http://id.biodiversity.org.au/node/ausmoss/10044764", nsr.getLsid());
+            assertEquals("http://id.biodiversity.org.au/node/ausmoss/10061546", nsr.getLsid());
             assertEquals("Breutelia", nsr.getRankClassification().getGenus());
             assertEquals(MatchType.RECURSIVE, nsr.getMatchType());
         } catch (SearchResultException e) {
@@ -1486,7 +1488,7 @@ public class ALANameSearcherTest {
             cl.setScientificName(name);
             NameSearchResult nsr = searcher.searchForRecord(cl, true);
             assertNotNull(nsr);
-            assertEquals("NZOR-4-1804", nsr.getLsid());
+            assertEquals("NZOR-6-1843", nsr.getLsid());
             assertEquals("Ramalina", nsr.getRankClassification().getGenus());
             assertEquals(MatchType.RECURSIVE, nsr.getMatchType());
         } catch (SearchResultException e) {
@@ -1497,7 +1499,7 @@ public class ALANameSearcherTest {
     @Test
     public void testHomonymWithOrderResolution1()  {
         try {
-            String name = "Tyto";
+            String name = "Abelia";
             LinnaeanRankClassification cl = new LinnaeanRankClassification();
             cl.setScientificName(name);
             NameSearchResult nsr = searcher.searchForRecord(cl, true);
@@ -1508,13 +1510,13 @@ public class ALANameSearcherTest {
             fail("Unexpected search exception " + e);
         }
         try {
-            String name = "Tyto";
+            String name = "Abelia";
             LinnaeanRankClassification cl = new LinnaeanRankClassification();
             cl.setScientificName(name);
-            cl.setOrder("Strigiformes");
+            cl.setOrder("Dipsacales");
             NameSearchResult nsr = searcher.searchForRecord(cl, true);
             assertNotNull(nsr);
-            assertEquals("urn:lsid:biodiversity.org.au:afd.taxon:97bc55da-8870-45ac-a828-97787740ad61", nsr.getLsid());
+            assertEquals("http://id.biodiversity.org.au/node/apni/2892114", nsr.getLsid());
         } catch (SearchResultException e) {
             fail("Unexpected search exception " + e);
         }

--- a/src/test/java/au/org/ala/names/search/BiocacheMatchTest.java
+++ b/src/test/java/au/org/ala/names/search/BiocacheMatchTest.java
@@ -436,8 +436,12 @@ public class BiocacheMatchTest {
             String name = "Canis lupus dingo";
             cl.setScientificName(name);
             MetricsResultDTO metrics = searcher.searchForRecordMetrics(cl, true);
-            assertEquals("urn:lsid:biodiversity.org.au:afd.taxon:c2056f1b-fcde-45b9-904b-1cab280368d1", metrics.getResult().getAcceptedLsid());
-            assertEquals(MatchType.EXACT, metrics.getResult().getMatchType());
+            assertNotNull(metrics);
+            assertEquals("NZOR-6-132827", metrics.getResult().getLsid());
+            assertEquals(MatchType.RECURSIVE, metrics.getResult().getMatchType());
+            NameSearchResult nsr = searcher.searchForCommonName(name);
+            assertNotNull(nsr);
+            assertEquals("urn:lsid:biodiversity.org.au:afd.taxon:c2056f1b-fcde-45b9-904b-1cab280368d1", nsr.getLsid());
         } catch (SearchResultException ex) {
             fail("Unexpected search exception " + ex);
         }

--- a/src/test/java/au/org/ala/names/search/BiocacheMatchTest.java
+++ b/src/test/java/au/org/ala/names/search/BiocacheMatchTest.java
@@ -23,7 +23,7 @@ public class BiocacheMatchTest {
     @org.junit.BeforeClass
     public static void init() {
         try {
-            searcher = new ALANameSearcher("/data/lucene/namematching-20170927");
+            searcher = new ALANameSearcher("/data/lucene/namematching-20181105");
         } catch (Exception e) {
             e.printStackTrace();
         }
@@ -102,7 +102,7 @@ public class BiocacheMatchTest {
         cl.setGenus("Graphis");
         cl.setSpecificEpithet("notreallyaname");
         MetricsResultDTO metrics = searcher.searchForRecordMetrics(cl, true);
-        assertEquals("NZOR-4-120184", metrics.getResult().getLsid()); // Can't find Graphis since not APC placed so gets Graphidaceae
+        assertEquals("NZOR-6-122770", metrics.getResult().getLsid()); // Can't find Graphis since not APC placed so gets Graphidaceae
     }
 
     @Test
@@ -151,7 +151,7 @@ public class BiocacheMatchTest {
             cl.setSpecificEpithet(spEp);
             MetricsResultDTO metrics = searcher.searchForRecordMetrics(cl, true);
             //System.out.println(metrics.getResult());
-            assertEquals("NZOR-4-56674", metrics.getResult().getLsid());
+            assertEquals("http://id.biodiversity.org.au/instance/apni/884433", metrics.getResult().getLsid());
             assertTrue(metrics.getErrors().contains(ErrorType.HOMONYM));
 
         } catch (Exception e) {
@@ -197,21 +197,10 @@ public class BiocacheMatchTest {
     @Test
     public void testHomonym() {
         try {
-            searcher.searchForRecord("Terebratella", null);
-            fail("Expected homonym exception");
+            NameSearchResult nsr = searcher.searchForRecord("Agathis", null);
+            fail("Expected homonym exception, got" + nsr);
         } catch (Exception e) {
             assertTrue(e instanceof HomonymException);
-        }
-    }
-
-    @Test
-    public void commonName() {
-        try {
-            //System.out.println(searcher.searchForCommonName("Red Kangaroo"));
-            // searcher.searchForLSID("Centropogon australis");
-            searcher.searchForRecord("Dexillus muelleri", null);
-        } catch (Exception e) {
-            e.printStackTrace();
         }
     }
 
@@ -227,7 +216,7 @@ public class BiocacheMatchTest {
             cl.setScientificName("Myosurus minimus");
             metrics = searcher.searchForRecordMetrics(cl, true);
             assertTrue(metrics.getErrors().contains(ErrorType.MATCH_MISAPPLIED));
-            assertEquals("NZOR-4-91924", metrics.getResult().getLsid());
+            assertEquals("NZOR-6-93927", metrics.getResult().getLsid());
         } catch (Exception e) {
             fail("No exception shoudl occur");
             e.printStackTrace();
@@ -441,7 +430,7 @@ public class BiocacheMatchTest {
     }
 
     @Test
-    public void tesDingo1()  {
+    public void testDingo1()  {
         try {
             LinnaeanRankClassification cl = new LinnaeanRankClassification();
             String name = "Canis lupus dingo";

--- a/src/test/java/au/org/ala/names/search/IconicSpeciesTest.java
+++ b/src/test/java/au/org/ala/names/search/IconicSpeciesTest.java
@@ -31,7 +31,7 @@ public class IconicSpeciesTest {
     @org.junit.BeforeClass
     public static void init() {
         try {
-            searcher = new ALANameSearcher("/data/lucene/namematching-20170927");
+            searcher = new ALANameSearcher("/data/lucene/namematching-20181105");
         } catch (Exception e) {
             e.printStackTrace();
         }

--- a/src/test/java/au/org/ala/names/search/VernacularMatchTest.java
+++ b/src/test/java/au/org/ala/names/search/VernacularMatchTest.java
@@ -25,7 +25,7 @@ public class VernacularMatchTest {
     @org.junit.BeforeClass
     public static void init() {
         try {
-            searcher = new ALANameSearcher("/data/lucene/namematching-20170927");
+            searcher = new ALANameSearcher("/data/lucene/namematching-20181105");
         } catch (Exception e) {
             e.printStackTrace();
         }
@@ -38,7 +38,8 @@ public class VernacularMatchTest {
         NameSearchResult result = null;
 
         result = searcher.searchForCommonName(name);
-        assertNull(result); // Has multiple matches
+        assertNotNull(result);
+        assertEquals(expectedLsid, result.getLsid());
     }
 
     @Ignore // Requires indidgenous names

--- a/src/test/java/org/gbif/nameparser/PhraseNameParserTest.java
+++ b/src/test/java/org/gbif/nameparser/PhraseNameParserTest.java
@@ -1,0 +1,74 @@
+
+
+package org.gbif.nameparser;
+
+import au.org.ala.names.model.ALAParsedName;
+import au.org.ala.names.util.CleanedScientificName;
+import org.codehaus.jackson.map.jsontype.NamedType;
+import org.gbif.api.model.checklistbank.ParsedName;
+import org.gbif.api.vocabulary.NameType;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ * Test cases for the phrase name parser.
+ * <p>
+ * Apart from a few tests to make sure that the parser is not screwing up "normal" parsing,
+ * these tests concentrate on
+ * </p>
+ */
+public class PhraseNameParserTest {
+    private PhraseNameParser parser;
+
+    @Before
+    public void setup() throws Exception {
+        this.parser = new PhraseNameParser();
+    }
+
+    @Test
+    public void testSimpleParse1() throws Exception {
+        ParsedName pn = parser.parse("Ozothamnus diosmifolius");
+        assertFalse(pn instanceof ALAParsedName);
+        assertEquals("Ozothamnus", pn.getGenusOrAbove());
+        assertEquals("diosmifolius", pn.getSpecificEpithet());
+        assertEquals(NameType.SCIENTIFIC, pn.getType());
+        assertNull(pn.getAuthorship());
+        assertEquals("Ozothamnus diosmifolius", pn.canonicalName());
+    }
+
+    @Test
+    public void testSimpleParse2() throws Exception {
+        ParsedName pn = parser.parse("Ozothamnus");
+        assertFalse(pn instanceof ALAParsedName);
+        assertEquals("Ozothamnus", pn.getGenusOrAbove());
+        assertNull(pn.getSpecificEpithet());
+        assertEquals(NameType.SCIENTIFIC, pn.getType());
+        assertNull(pn.getAuthorship());
+        assertEquals("Ozothamnus", pn.canonicalName());
+    }
+
+    @Test
+    public void testSpeciesPlaceholder1() throws Exception {
+        ParsedName pn = parser.parse("Diaporthe species1");
+        assertFalse(pn instanceof ALAParsedName);
+        assertEquals("Diaporthe", pn.getGenusOrAbove());
+        assertEquals("species1", pn.getSpecificEpithet());
+        assertEquals(NameType.SCIENTIFIC, pn.getType());
+        assertNull(pn.getAuthorship());
+        assertEquals("Diaporthe species1", pn.canonicalName());
+    }
+
+    @Test
+    public void testSpeciesPlaceholder2() throws Exception {
+        ParsedName pn = parser.parse("Diaporthe species 1");
+        assertFalse(pn instanceof ALAParsedName);
+        assertEquals("Diaporthe", pn.getGenusOrAbove());
+        assertEquals("1", pn.getSpecificEpithet());
+        assertEquals(NameType.SCIENTIFIC, pn.getType());
+        assertNull(pn.getAuthorship());
+        assertEquals("Diaporthe 1", pn.canonicalName());
+    }
+
+}

--- a/src/test/java/org/gbif/nameparser/PhraseNameParserTest.java
+++ b/src/test/java/org/gbif/nameparser/PhraseNameParserTest.java
@@ -55,7 +55,7 @@ public class PhraseNameParserTest {
         assertFalse(pn instanceof ALAParsedName);
         assertEquals("Diaporthe", pn.getGenusOrAbove());
         assertEquals("species1", pn.getSpecificEpithet());
-        assertEquals(NameType.SCIENTIFIC, pn.getType());
+        assertEquals(NameType.PLACEHOLDER, pn.getType());
         assertNull(pn.getAuthorship());
         assertEquals("Diaporthe species1", pn.canonicalName());
     }
@@ -65,10 +65,21 @@ public class PhraseNameParserTest {
         ParsedName pn = parser.parse("Diaporthe species 1");
         assertFalse(pn instanceof ALAParsedName);
         assertEquals("Diaporthe", pn.getGenusOrAbove());
-        assertEquals("1", pn.getSpecificEpithet());
-        assertEquals(NameType.SCIENTIFIC, pn.getType());
+        assertEquals("species-1", pn.getSpecificEpithet());
+        assertEquals(NameType.PLACEHOLDER, pn.getType());
         assertNull(pn.getAuthorship());
-        assertEquals("Diaporthe 1", pn.canonicalName());
+        assertEquals("Diaporthe species-1", pn.canonicalName());
+    }
+
+    @Test
+    public void testSpeciesPlaceholder3() throws Exception {
+        ParsedName pn = parser.parse("Diaporthe species-1");
+        assertFalse(pn instanceof ALAParsedName);
+        assertEquals("Diaporthe", pn.getGenusOrAbove());
+        assertEquals("species-1", pn.getSpecificEpithet());
+        assertEquals(NameType.PLACEHOLDER, pn.getType());
+        assertNull(pn.getAuthorship());
+        assertEquals("Diaporthe species-1", pn.canonicalName());
     }
 
 }

--- a/src/test/resources/au/org/ala/names/index/dwca-1/meta.xml
+++ b/src/test/resources/au/org/ala/names/index/dwca-1/meta.xml
@@ -1,0 +1,42 @@
+<archive xmlns="http://rs.tdwg.org/dwc/text/">
+  <core encoding="UTF-8" fieldsTerminatedBy="," linesTerminatedBy="\n" fieldsEnclosedBy="&quot;" ignoreHeaderLines="1" rowType="http://rs.tdwg.org/dwc/terms/Taxon">
+    <files>
+      <location>taxon.csv</location>
+    </files>
+    <id index="0" />
+    <field index="0" term="http://rs.tdwg.org/dwc/terms/taxonID"/>
+    <field index="1" term="http://rs.tdwg.org/dwc/terms/parentNameUsageID"/>
+    <field index="2" term="http://rs.tdwg.org/dwc/terms/acceptedNameUsageID"/>
+    <field index="3" term="http://rs.tdwg.org/dwc/terms/datasetID"/>
+    <field index="4" term="http://rs.tdwg.org/dwc/terms/nomenclaturalCode"/>
+    <field index="5" term="http://rs.tdwg.org/dwc/terms/scientificName"/>
+    <field index="6" term="http://rs.tdwg.org/dwc/terms/scientificNameAuthorship"/>
+    <field index="7" term="http://rs.tdwg.org/dwc/terms/taxonRank"/>
+    <field index="8" term="http://rs.tdwg.org/dwc/terms/taxonConceptID"/>
+    <field index="9" term="http://rs.tdwg.org/dwc/terms/scientificNameID"/>
+    <field index="10" term="http://rs.tdwg.org/dwc/terms/taxonomicStatus"/>
+    <field index="11" term="http://rs.tdwg.org/dwc/terms/nomenclaturalStatus"/>
+    <field index="12" term="http://rs.tdwg.org/dwc/terms/establishmentMeans"/>
+    <field index="13" term="http://rs.tdwg.org/dwc/terms/nameAccordingToID"/>
+    <field index="14" term="http://rs.tdwg.org/dwc/terms/nameAccordingTo"/>
+    <field index="15" term="http://rs.tdwg.org/dwc/terms/namePublishedInID"/>
+    <field index="16" term="http://rs.tdwg.org/dwc/terms/namePublishedIn"/>
+    <field index="17" term="http://rs.tdwg.org/dwc/terms/namePublishedInYear"/>
+    <field index="18" term="http://ala.org.au/terms/1.0/nameComplete"/>
+    <field index="19" term="http://ala.org.au/terms/1.0/nameFormatted"/>
+    <field index="20" term="http://purl.org/dc/terms/source"/>
+  </core>
+  <extension encoding="UTF-8" fieldsTerminatedBy="," linesTerminatedBy="\n" fieldsEnclosedBy="&quot;" ignoreHeaderLines=
+"1" rowType="http://rs.gbif.org/terms/1.0/VernacularName">
+    <files>
+      <location>vernacularNames.csv</location>
+    </files>
+    <coreid index="0" />
+    <field index="0" term="http://rs.tdwg.org/dwc/terms/taxonID"/>
+    <field index="1" term="http://ala.org.au/terms/1.0/nameID"/>
+    <field index="2" term="http://rs.tdwg.org/dwc/terms/datasetID"/>
+    <field index="3" term="http://rs.tdwg.org/dwc/terms/vernacularName"/>
+    <field index="4" term="http://ala.org.au/terms/1.0/status"/>
+    <field index="5" term="http://purl.org/dc/terms/language"/>
+  </extension>
+</archive>

--- a/src/test/resources/au/org/ala/names/index/dwca-1/taxon.csv
+++ b/src/test/resources/au/org/ala/names/index/dwca-1/taxon.csv
@@ -1,0 +1,3 @@
+taxonID,parentNameUsageID,acceptedNameUsageID,datasetID,nomenclaturalCode,scientificName,scientificNameAuthorship,taxonRank,taxonConceptID,scientificNameID,taxonomicStatus,nomenclaturalStatus,establishmentMeans,nameAccordingToID,nameAccordingTo,namePublishedInID,namePublishedIn,namePubishedInYear,nameComplete,nameFormatted,source
+"urn:lsid:biodiversity.org.au:afd.taxon:c2056f1b-fcde-45b9-904b-1cab280368d1","","","dr100","ICZN","Canis famliaris","Linnaeus, 1758","species","","","accepted","","","","","","","","","",""
+"ALA_Canis_lupus_dingo","","","dr101","ICZN","Canis lupus dingo","","unranked","","","inferredAccepted","","","","","","","","","",""

--- a/src/test/resources/au/org/ala/names/index/dwca-1/vernacularNames.csv
+++ b/src/test/resources/au/org/ala/names/index/dwca-1/vernacularNames.csv
@@ -1,0 +1,2 @@
+taxonID,nameID,datasetID,vernacularName,status,language
+"urn:lsid:biodiversity.org.au:afd.taxon:c2056f1b-fcde-45b9-904b-1cab280368d1","urn:lsid:biodiversity.org.au:afd.name:642215","dr100","Canis lupus dingo","miscellaneousLiterature",""

--- a/src/test/resources/au/org/ala/names/index/taxonomy-24.csv
+++ b/src/test/resources/au/org/ala/names/index/taxonomy-24.csv
@@ -1,0 +1,4 @@
+taxonID,parentNameUsageID,acceptedNameUsageID,datasetID,nomenclaturalCode,scientificName,scientificNameAuthorship,taxonRank,taxonConceptID,scientificNameID,taxonomicStatus,nomenclaturalStatus,establishmentMeans,nameAccordingToID,nameAccordingTo,namePublishedInID,namePublishedIn,namePubishedInYear,nameComplete,nameFormatted,source
+"Accepted-1","","","dr105","ICBN","Anakinetica cumingii cumingii","Davidson","subspecies","","","accepted","","","","","","","","","",""
+"Accepted-2","","","dr100","ICBN","Anakinetica cumingii cumingii","Davidson","subspecies","","","accepted","","","","","","","","","",""
+"Synonym-1","","Accepted-1","dr105","ICBN","Terebratella cumingii calamus","Davidson","","","","synonym","","","","","","","","","",""

--- a/src/test/resources/au/org/ala/names/index/taxonomy-25.csv
+++ b/src/test/resources/au/org/ala/names/index/taxonomy-25.csv
@@ -1,0 +1,5 @@
+taxonID,parentNameUsageID,acceptedNameUsageID,datasetID,nomenclaturalCode,scientificName,scientificNameAuthorship,taxonRank,taxonConceptID,scientificNameID,taxonomicStatus,nomenclaturalStatus,establishmentMeans,nameAccordingToID,nameAccordingTo,namePublishedInID,namePublishedIn,namePubishedInYear,nameComplete,nameFormatted,source
+"Accepted-1","","","dr110","ICBN","Anakinetica cumingii cumingii","Davidson","subspecies","","","accepted","","","","","","","","","",""
+"Accepted-2","","","dr100","ICBN","Anakinetica cumingii cumingii","Davidson","subspecies","","","accepted","","","","","","","","","",""
+"Synonym-1","","Accepted-1","dr110","ICBN","Terebratella cumingii var. calamus","Davidson","","","","synonym","","","","","","","","","",""
+"Synonym-2","","Accepted-2","dr100","ICBN","Terebratella cumingii calamus","Davidson","","","","synonym","","","","","","","","","",""

--- a/src/test/resources/au/org/ala/names/index/taxonomy-26.csv
+++ b/src/test/resources/au/org/ala/names/index/taxonomy-26.csv
@@ -1,0 +1,4 @@
+taxonID,parentNameUsageID,acceptedNameUsageID,datasetID,nomenclaturalCode,scientificName,scientificNameAuthorship,taxonRank,taxonConceptID,scientificNameID,taxonomicStatus,nomenclaturalStatus,establishmentMeans,nameAccordingToID,nameAccordingTo,namePublishedInID,namePublishedIn,namePubishedInYear,nameComplete,nameFormatted,source
+"http://id.biodiversity.org.au/node/apni/50587232","","","dr100","ICBN","Plantae","Haeckel","kingdom","","","accepted","","","","","","","","","",""
+"NZOR-6-60501","","","dr107","ICBN","Plantae","Haeckel","kingdom","","","accepted","","","","","","","","","",""
+"http://id.biodiversity.org.au/name/ausmoss/10001168","","","dr101","ICBN","Plantae","Haeckel","kingdom","","","unplaced","","","","","","","","","",""

--- a/src/test/resources/au/org/ala/names/index/taxonomy-config-2.json
+++ b/src/test/resources/au/org/ala/names/index/taxonomy-config-2.json
@@ -107,6 +107,11 @@
       ]
     },
     "defaultScore" : 100
+  },{
+    "id" : "dr110",
+    "parent": "unknown",
+    "unrankedStrategy": "SYNONYMS_INFER",
+    "defaultScore" : 150
   }],
   "defaultProvider" : "unknown",
   "acceptedCutoff" : 50

--- a/src/test/resources/au/org/ala/names/search/iconic_species_list.csv
+++ b/src/test/resources/au/org/ala/names/search/iconic_species_list.csv
@@ -133,7 +133,7 @@ INVERTEBRATES
 ,Red-eyed Cicada,,Animalia,Arthropoda,Insecta,HEMIPTERA,CICADIDAE,Psaltoda,moerens,,,yes,yes,yes
 ,Green grocer Ciciada,,Animalia,Arthropoda,Insecta,HEMIPTERA,CICADIDAE,Cyclochila,australasiae,,,yes,yes,yes
 ,Blue Ringed Octopus,,Animalia,MOLLUSCA,CEPHALOPODA,OCTOPODA,OCTOPODIDAE,Hapalochlaena,maculosa,,,yes,yes,yes
-,Golden Orb-Weaver,,Animalia,Arthropoda,Arachnida,ARANEAE,NEPHILIDAE,Nephila,plumipes,,,yes,yes,yes
+,Golden Orb-Weaver,,Animalia,Arthropoda,Arachnida,ARANEAE,Araneidae,Nephila,plumipes,,,yes,yes,yes
 ,White-tailed Spider,,Animalia,Arthropoda,Arachnida,ARANEAE,LAMPONIDAE,Lampona,cylindrata,,,yes,yes,yes
 ,Bogong Moth,,Animalia,Arthropoda,Insecta,LEPIDOPTERA,NOCTUIDAE,Agrotis,infusa,,,yes,yes,No
 ,Box jelly-fish,,Animalia,,,,,Chironex,fleckeri,,,yes,No,No


### PR DESCRIPTION
Also incertae sedis fixes, improvements to unranked matching and test cases against an updated taxonomy.

Miscellaneous literature and legislated names have been moved to being vernacular names. A pseudo-taxon is introduced to catch any names that are introduced by other sources.