### PR TITLE
Fix for issue #61

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ before_install:
 - mkdir -p ~/.m2; wget -q -O ~/.m2/settings.xml https://raw.githubusercontent.com/AtlasOfLivingAustralia/travis-build-configuration/master/travis_maven_settings_simple.xml
 - sudo mkdir -p /data/lucene; sudo wget -O /data/lucene/namematching-20181120.tgz http://archives.ala.org.au/archives/nameindexes/20181120/namematching-20181120.tgz
 - cd /data/lucene
-- sudo tar zxvf namematching-20181120.tgz
-- sudo ln -s namematching-20181120 namematching
+- sudo tar zxvf namematching-20190213.tgz
+- sudo ln -s namematching-20190213 namematching
 - ls -laF
 - cd $TRAVIS_BUILD_DIR
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ branches:
 
 before_install:
 - mkdir -p ~/.m2; wget -q -O ~/.m2/settings.xml https://raw.githubusercontent.com/AtlasOfLivingAustralia/travis-build-configuration/master/travis_maven_settings_simple.xml
-- sudo mkdir -p /data/lucene; sudo wget -O /data/lucene/namematching-20181120.tgz http://archives.ala.org.au/archives/nameindexes/20181120/namematching-20181120.tgz
+- sudo mkdir -p /data/lucene; sudo wget -O /data/lucene/namematching-20190213.tgz http://archives.ala.org.au/archives/nameindexes/20190213/namematching-20190213.tgz
 - cd /data/lucene
 - sudo tar zxvf namematching-20190213.tgz
 - sudo ln -s namematching-20190213 namematching

--- a/src/test/java/au/org/ala/names/search/ALANameSearcherTest.java
+++ b/src/test/java/au/org/ala/names/search/ALANameSearcherTest.java
@@ -20,7 +20,7 @@ public class ALANameSearcherTest {
 
     @org.junit.BeforeClass
     public static void init() throws Exception {
-        searcher = new ALANameSearcher("/data/lucene/namematching-20181120");
+        searcher = new ALANameSearcher("/data/lucene/namematching-20190213");
     }
 
     @Test
@@ -1555,6 +1555,43 @@ public class ALANameSearcherTest {
         } catch (SearchResultException e) {
             fail("Unexpected search exception " + e);
         }
+    }
+
+    @Test
+    public void testMultipleMisappliedResolution1() throws Exception {
+        String name = "Cressa cretica";
+        LinnaeanRankClassification cl = new LinnaeanRankClassification();
+        cl.setScientificName(name);
+        MetricsResultDTO metrics = searcher.searchForRecordMetrics(cl, true);
+        assertNotNull(metrics);
+        assertEquals("http://id.biodiversity.org.au/node/apni/2887824", metrics.getResult().getLsid());
+        assertEquals(MatchType.TAXON_ID, metrics.getResult().getMatchType());
+        assertTrue(metrics.getErrors().contains(ErrorType.MISAPPLIED));
+    }
+
+    @Test
+    public void testMultipleMisappliedResolution2() throws Exception {
+        String name = "Acrotriche divaricata";
+        LinnaeanRankClassification cl = new LinnaeanRankClassification();
+        cl.setScientificName(name);
+        MetricsResultDTO metrics = searcher.searchForRecordMetrics(cl, true);
+        assertNotNull(metrics);
+        assertEquals("http://id.biodiversity.org.au/node/apni/2905435", metrics.getResult().getLsid());
+        assertEquals(MatchType.EXACT, metrics.getResult().getMatchType());
+        assertTrue(metrics.getErrors().contains(ErrorType.MATCH_MISAPPLIED));
+    }
+
+    // Multiple misapplied, to different things.
+    @Test
+    public void testMultipleMisappliedResolution3() throws Exception {
+        String name = "Potamogeton obtusifolius";
+        LinnaeanRankClassification cl = new LinnaeanRankClassification();
+        cl.setScientificName(name);
+        MetricsResultDTO metrics = searcher.searchForRecordMetrics(cl, true);
+        assertNotNull(metrics);
+        assertEquals("http://id.biodiversity.org.au/node/apni/8770682", metrics.getResult().getLsid());
+        assertEquals(MatchType.RECURSIVE, metrics.getResult().getMatchType());
+        assertTrue(metrics.getErrors().contains(ErrorType.MISAPPLIED));
     }
 
 }

--- a/src/test/java/au/org/ala/names/search/BiocacheMatchTest.java
+++ b/src/test/java/au/org/ala/names/search/BiocacheMatchTest.java
@@ -22,7 +22,7 @@ public class BiocacheMatchTest {
 
     @org.junit.BeforeClass
     public static void init() throws Exception {
-        searcher = new ALANameSearcher("/data/lucene/namematching-20181120");
+        searcher = new ALANameSearcher("/data/lucene/namematching-20190213");
     }
 
     @Test
@@ -209,14 +209,13 @@ public class BiocacheMatchTest {
         assertEquals("http://id.biodiversity.org.au/node/apni/2894621", metrics.getResult().getLsid());
     }
 
-    // Should go to higher taxon because there is no accepted match
     @Test
     public void testMisappliedNames2() throws Exception {
         LinnaeanRankClassification cl = new LinnaeanRankClassification();
         cl.setScientificName("Myosurus minimus");
         MetricsResultDTO metrics = searcher.searchForRecordMetrics(cl, true);
         assertTrue(metrics.getErrors().contains(ErrorType.MISAPPLIED));
-        assertEquals("http://id.biodiversity.org.au/node/apni/2896644", metrics.getResult().getLsid());
+        assertEquals("http://id.biodiversity.org.au/node/apni/2917549", metrics.getResult().getLsid());
     }
 
     @Test

--- a/src/test/java/au/org/ala/names/search/IconicSpeciesTest.java
+++ b/src/test/java/au/org/ala/names/search/IconicSpeciesTest.java
@@ -30,7 +30,7 @@ public class IconicSpeciesTest {
 
     @org.junit.BeforeClass
     public static void init() throws Exception {
-        searcher = new ALANameSearcher("/data/lucene/namematching-20181120");
+        searcher = new ALANameSearcher("/data/lucene/namematching-20190213");
     }
 
     //@Test

--- a/src/test/java/au/org/ala/names/search/VernacularMatchTest.java
+++ b/src/test/java/au/org/ala/names/search/VernacularMatchTest.java
@@ -24,7 +24,7 @@ public class VernacularMatchTest {
 
     @org.junit.BeforeClass
     public static void init() throws Exception {
-        searcher = new ALANameSearcher("/data/lucene/namematching-20181120");
+        searcher = new ALANameSearcher("/data/lucene/namematching-20190213");
      }
 
     @Test


### PR DESCRIPTION
Allow multiple references to a single misapplied name if that name resolves back onto the same taxon.
Update test index.

https://github.com/AtlasOfLivingAustralia/ala-name-matching/issues/61