### PR TITLE
Issue 79

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 sudo: required
 language: java
 jdk:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ branches:
 
 before_install:
 - mkdir -p ~/.m2; wget -q -O ~/.m2/settings.xml https://raw.githubusercontent.com/AtlasOfLivingAustralia/travis-build-configuration/master/travis_maven_settings_simple.xml
-- sudo mkdir -p /data/lucene; sudo wget -O /data/lucene/namematching-20190213.tgz http://archives.ala.org.au/archives/nameindexes/20190213/namematching-20190213.tgz
+- sudo mkdir -p /data/lucene; sudo wget -O /data/lucene/namematching-20190213.tgz https://archives.ala.org.au/archives/nameindexes/20190213/namematching-20190213.tgz
 - cd /data/lucene
 - sudo tar zxvf namematching-20190213.tgz
 - sudo ln -s namematching-20190213 namematching

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ jdk:
 branches:
   only:
   - master
+  - develop
 
 before_install:
 - mkdir -p ~/.m2; wget -q -O ~/.m2/settings.xml https://raw.githubusercontent.com/AtlasOfLivingAustralia/travis-build-configuration/master/travis_maven_settings_simple.xml

--- a/data/ala-taxon-config.json
+++ b/data/ala-taxon-config.json
@@ -630,7 +630,8 @@
         "Plantae": 6000
       },
       "owner": [
-        "Plantae"
+        "Plantae",
+        "Solanum torvum"
       ]
     },
     {
@@ -720,5 +721,7 @@
     }
   ],
   "defaultProvider" : "dr5393",
-  "inferenceProvider" : "dr5393"
+  "inferenceProvider" : "dr5393",
+  "authorMap": {
+  }
 }

--- a/src/main/java/au/org/ala/names/index/ALANameAnalyser.java
+++ b/src/main/java/au/org/ala/names/index/ALANameAnalyser.java
@@ -126,7 +126,8 @@ public class ALANameAnalyser extends NameAnalyser {
     private NameParser nameParser;
     private NomStatusParser nomStatusParser;
 
-    public ALANameAnalyser() {
+    public ALANameAnalyser(AuthorComparator authorComparator, Reporter reporter) {
+        super(authorComparator, reporter);
         this.nameParser = new PhraseNameParser();
         this.nomStatusParser = NomStatusParser.getInstance();
         this.buildCodeMap();
@@ -134,6 +135,10 @@ public class ALANameAnalyser extends NameAnalyser {
         this.buildRankMap();
         this.buildNomenclaturalStatusMap();
         this.buildInformalPatternList();
+    }
+
+    public ALANameAnalyser() {
+        this(AuthorComparator.createWithAuthormap(), null);
     }
 
     /**

--- a/src/main/java/au/org/ala/names/index/NameAnalyser.java
+++ b/src/main/java/au/org/ala/names/index/NameAnalyser.java
@@ -32,9 +32,15 @@ abstract public class NameAnalyser implements Comparator<NameKey>, Reporter {
     private Reporter reporter;
     private AuthorComparator authorComparator;
 
-
-    public NameAnalyser() {
-        this.authorComparator = AuthorComparator.createWithAuthormap();
+    /**
+     * Constructor.
+     *
+     * @param authorComparator The author comparator to use
+     * @param reporter The reporter to use
+     */
+    public NameAnalyser(AuthorComparator authorComparator, Reporter reporter) {
+        this.authorComparator = authorComparator;
+        this.reporter = reporter;
     }
 
     /**

--- a/src/main/java/au/org/ala/names/index/Taxonomy.java
+++ b/src/main/java/au/org/ala/names/index/Taxonomy.java
@@ -27,6 +27,7 @@ import org.gbif.api.model.registry.Contact;
 import org.gbif.api.model.registry.Dataset;
 import org.gbif.api.model.registry.Identifier;
 import org.gbif.api.vocabulary.*;
+import org.gbif.checklistbank.authorship.AuthorComparator;
 import org.gbif.dwc.terms.*;
 import org.gbif.dwc.terms.Term;
 import org.slf4j.Logger;
@@ -180,8 +181,7 @@ public class Taxonomy implements Reporter {
         this.configuration = configuration;
         this.configuration.validate();
         try {
-            this.analyser = this.configuration.nameAnalyserClass.newInstance();
-            this.analyser.setReporter(this);
+            this.analyser = this.configuration.nameAnalyserClass.getConstructor(AuthorComparator.class, Reporter.class).newInstance(this.configuration.newAuthorComparator(), this);
         } catch (Exception ex) {
             throw new IndexBuilderException("Unable to create analyser", ex);
         }

--- a/src/test/java/au/org/ala/names/index/TaxonomyConfiugrationTest.java
+++ b/src/test/java/au/org/ala/names/index/TaxonomyConfiugrationTest.java
@@ -3,6 +3,8 @@ package au.org.ala.names.index;
 import au.org.ala.names.util.TestUtils;
 import org.gbif.api.model.registry.Contact;
 import org.gbif.api.vocabulary.NomenclaturalCode;
+import org.gbif.checklistbank.authorship.AuthorComparator;
+import org.gbif.checklistbank.model.Equality;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -138,5 +140,28 @@ public class TaxonomyConfiugrationTest extends TestUtils {
         assertNull(properties.getProperty("drNotADataset"));
     }
 
+    @Test
+    public void testNewAuthorMap1() throws Exception {
+        TaxonomyConfiguration config = TaxonomyConfiguration.read(this.resourceReader("taxonomy-config-2.json"));
+        AuthorComparator comparator = config.newAuthorComparator();
+
+        assertEquals(Equality.EQUAL, comparator.compare("Linnaeus", null, "Linnaeus", null));
+        assertEquals(Equality.EQUAL, comparator.compare("L.", null, "Linnaeus", null));
+        assertEquals(Equality.DIFFERENT, comparator.compare("Linnaeus", null, "Fred", null));
+        assertEquals(Equality.DIFFERENT, comparator.compare("Sweet", null, "Sw.", null));
+        assertEquals(Equality.DIFFERENT, comparator.compare("SZ", null, "S Zhu", null));
+    }
+
+    @Test
+    public void testNewAuthorMap2() throws Exception {
+        TaxonomyConfiguration config = TaxonomyConfiguration.read(this.resourceReader("taxonomy-config-4.json"));
+        AuthorComparator comparator = config.newAuthorComparator();
+
+        assertEquals(Equality.EQUAL, comparator.compare("Linnaeus", null, "Linnaeus", null));
+        assertEquals(Equality.EQUAL, comparator.compare("L.", null, "Linnaeus", null));
+        assertEquals(Equality.DIFFERENT, comparator.compare("Linnaeus", null, "Fred", null));
+        assertEquals(Equality.EQUAL, comparator.compare("Sweet", null, "Sw.", null));
+        assertEquals(Equality.EQUAL, comparator.compare("SZ", null, "S Zhu", null));
+    }
 
 }

--- a/src/test/java/au/org/ala/names/index/TaxonomyTest.java
+++ b/src/test/java/au/org/ala/names/index/TaxonomyTest.java
@@ -478,7 +478,7 @@ public class TaxonomyTest extends TestUtils {
         assertEquals(12, this.rowCount(new File(dir, "taxon.txt")));
         assertEquals(22, this.rowCount(new File(dir, "taxonvariant.txt")));
         assertEquals(52, this.rowCount(new File(dir, "identifier.txt")));
-        assertEquals(13, this.rowCount(new File(dir, "rightsholder.txt")));
+        assertEquals(14, this.rowCount(new File(dir, "rightsholder.txt")));
 
     }
 
@@ -499,7 +499,7 @@ public class TaxonomyTest extends TestUtils {
         assertEquals(5, this.rowCount(new File(dir, "taxon.txt")));
         assertEquals(6, this.rowCount(new File(dir, "taxonvariant.txt")));
         assertEquals(6, this.rowCount(new File(dir, "identifier.txt")));
-        assertEquals(14, this.rowCount(new File(dir, "rightsholder.txt")));
+        assertEquals(15, this.rowCount(new File(dir, "rightsholder.txt")));
     }
 
 
@@ -649,7 +649,7 @@ public class TaxonomyTest extends TestUtils {
         assertEquals(6, this.rowCount(new File(dir, "taxon.txt")));
         assertEquals(11, this.rowCount(new File(dir, "taxonvariant.txt")));
         assertEquals(11, this.rowCount(new File(dir, "identifier.txt")));
-        assertEquals(13, this.rowCount(new File(dir, "rightsholder.txt")));
+        assertEquals(14, this.rowCount(new File(dir, "rightsholder.txt")));
     }
 
     // Test the presence of a taxon loop

--- a/src/test/resources/au/org/ala/names/index/taxonomy-config-1.json
+++ b/src/test/resources/au/org/ala/names/index/taxonomy-config-1.json
@@ -22,5 +22,6 @@
     "unknownTaxonID" : "ALA_The_Unknown_Taxon"
   } ],
   "defaultProvider" : "ID-1",
-  "acceptedCutoff" : 50
+  "acceptedCutoff" : 50,
+  "authorMap" : { }
 }

--- a/src/test/resources/au/org/ala/names/index/taxonomy-config-2.json
+++ b/src/test/resources/au/org/ala/names/index/taxonomy-config-2.json
@@ -119,5 +119,6 @@
   }
   ],
   "defaultProvider" : "unknown",
-  "acceptedCutoff" : 50
+  "acceptedCutoff" : 50,
+  "authorMap" : { }
 }

--- a/src/test/resources/au/org/ala/names/index/taxonomy-config-4.json
+++ b/src/test/resources/au/org/ala/names/index/taxonomy-config-4.json
@@ -45,5 +45,8 @@
   } ],
   "defaultProvider" : "ID-1",
   "acceptedCutoff" : 50,
-  "authorMap" : { }
+  "authorMap": {
+    "Sw.": "Sweet",
+    "SZ": "S Zhu"
+  }
 }


### PR DESCRIPTION
Fixes for issue #79

This allows configurable author abbreviation mapping.
It turns out that this isn't necessary for issue 79 but, hey, it's worth having anyway.