### PR TITLE
Report on clashing accepted ranks in unranked names.

### DIFF
--- a/data/ala-taxon-config.json
+++ b/data/ala-taxon-config.json
@@ -667,6 +667,18 @@
             "scientificName": "ROOT"
           }
         ]
+      },
+      "keyAdjuster": {
+        "adjustments": [
+          {
+            "condition": {
+              "@class": "au.org.ala.names.index.provider.MatchTaxonCondition",
+              "scientificName": "Rotifera",
+              "taxonRank": "CLASS"
+            },
+            "rank": "PHYLUM"
+          }
+        ]
       }
     },
     {

--- a/src/main/java/au/org/ala/names/index/UnrankedScientificName.java
+++ b/src/main/java/au/org/ala/names/index/UnrankedScientificName.java
@@ -68,6 +68,9 @@ public class UnrankedScientificName extends Name<UnrankedScientificName, BareNam
      *     <li>If there is only one ranked scientific name, then that is it.</li>
      *     <li>If there is more than one ranked scientific name, then choose the one with a principal with the highest score. (Or the first if there are multiple ones)</li>
      * </ul>
+     *
+     * If there is an issue with clashing ranks, make a report.
+     *
      * @param taxonomy The resolving taxonomy.
      *
      * @return The principal
@@ -82,6 +85,9 @@ public class UnrankedScientificName extends Name<UnrankedScientificName, BareNam
         names.sort(REVERSE_PROVIDER_SCORE_COMPARATOR);
         final int cutoff = taxonomy.getAcceptedCutoff();
         List<ScientificName> ranked = names.stream().filter(sn -> !sn.getKey().isUnranked() && sn.getPrincipal() != null && sn.getPrincipalScore() > cutoff).collect(Collectors.toList());
+        Set<RankType> acceptedRanks = ranked.stream().filter(sn -> sn.getPrincipal().getRepresentative().isAccepted()).map(ScientificName::getRank).collect(Collectors.toSet());
+        if (acceptedRanks.size() > 1)
+            taxonomy.report(IssueType.PROBLEM, "unrankedScientificName.rankCollision", this, ranked);
         if (ranked.size() == 0)
             return names.get(0);
         if (ranked.size() == 1) {

--- a/src/main/resources/taxonomy.properties
+++ b/src/main/resources/taxonomy.properties
@@ -122,6 +122,7 @@ unknownTaxon.taxonRemarks=A taxon introduced to catch cases where parent or acce
   usually in the form of a loop of synonyms.
 unrankedScientificName.collision=Unranked scientific name {3} collision between scientific names {4}
 unrankedScientificName.collision.warn=Unranked scientific name {3} has multiple candidates, choosing first from {4}
+unrankedScientificName.rankCollision=Unranked scientific name {3} has accepted names of differing ranks {4}
 unrankedScientificName.reallocated=Unranked scientific name {3} reallocated to {4}
 unrankedScientificName.reallocated.provenance=Unranked scientific name reallocated to {1} by taxonomy builder
 vernacularName.unplaced=Unable to find corresponding taxon for {2} with scientific name {1}


### PR DESCRIPTION
Special case for Rotifera iun NZOR. These will have to be done on an ad-hoc basis, since taxa from the same source also have rank collisions.
See #70