### PR TITLE
Fix for synonym/misapplied clash

### DIFF
--- a/src/main/java/au/org/ala/names/search/ALANameSearcher.java
+++ b/src/main/java/au/org/ala/names/search/ALANameSearcher.java
@@ -1309,11 +1309,11 @@ public class ALANameSearcher {
 
     private void checkForMisapplied(List<NameSearchResult> results) throws MisappliedException {
         if (results.size() >= 1 && results.stream().anyMatch(r -> r.getSynonymType() == SynonymType.MISAPPLIED)) {
-            List<NameSearchResult> accepted = results.stream().filter(r -> !r.isSynonym()).collect(Collectors.toList());
+            List<NameSearchResult> accepted = results.stream().filter(r -> !r.isSynonym() || (r.isSynonym() && r.getSynonymType() != SynonymType.MISAPPLIED && r.getSynonymType() != SynonymType.EXCLUDES)).collect(Collectors.toList());
             List<NameSearchResult> misapplied = results.stream().filter(r -> r.getSynonymType() == SynonymType.MISAPPLIED).collect(Collectors.toList());
             Set<String> misAccepted = misapplied.stream().map(NameSearchResult::getAcceptedLsid).collect(Collectors.toSet());
             NameSearchResult matched = searchForRecordByLsid(misapplied.get(0).getAcceptedLsid());
-            // There ia an accepted version, as well
+            // There ia an accepted or usuable synonym version, as well, use it
             if (!accepted.isEmpty()) {
                 throw new MisappliedException(accepted.get(0), matched);
             }

--- a/src/test/java/au/org/ala/names/search/ALANameSearcherTest.java
+++ b/src/test/java/au/org/ala/names/search/ALANameSearcherTest.java
@@ -1619,4 +1619,20 @@ public class ALANameSearcherTest {
         assertTrue(metrics.getErrors().contains(ErrorType.MISAPPLIED));
     }
 
+
+    // Available as a synonym but also misapplied.
+    @Test
+    public void testSynonymMisapplied1() throws Exception {
+        String name = "Commersonia fraseri ";
+        LinnaeanRankClassification cl = new LinnaeanRankClassification();
+        cl.setScientificName(name);
+        MetricsResultDTO metrics = searcher.searchForRecordMetrics(cl, true);
+        assertNotNull(metrics);
+        assertEquals(SynonymType.OBJECTIVE_SYNONYM, metrics.getResult().getSynonymType());
+        assertEquals("https://id.biodiversity.org.au/instance/apni/948382", metrics.getResult().getLsid());
+        assertEquals("https://id.biodiversity.org.au/node/apni/2916208", metrics.getResult().getAcceptedLsid());
+        assertEquals(MatchType.EXACT, metrics.getResult().getMatchType());
+        assertTrue(metrics.getErrors().contains(ErrorType.MATCH_MISAPPLIED));
+    }
+
 }


### PR DESCRIPTION
Fix for issue #100 where synonyms are not considered properly against misapplied names.