### PR TITLE
Version to use with Lucene 8 (8.1.0)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,15 +10,15 @@ branches:
 
 before_install:
 - mkdir -p ~/.m2; wget -q -O ~/.m2/settings.xml https://raw.githubusercontent.com/AtlasOfLivingAustralia/travis-build-configuration/master/travis_maven_settings_simple.xml
-- sudo mkdir -p /data/lucene; sudo wget -O /data/lucene/namematching-20200214.tgz https://archives.ala.org.au/archives/nameindexes/20200214/namematching-20200214.tgz
+- sudo mkdir -p /data/lucene; sudo wget -O /data/lucene/namematching-20200214-lucene8.tgz https://archives.ala.org.au/archives/nameindexes/20200214/namematching-20200214-lucene8.tgz
 - cd /data/lucene
-- sudo tar zxvf namematching-20200214.tgz
-- sudo ln -s namematching-20200214 namematching
+- sudo tar zxvf namematching-20200214-lucene8.tgz
+- sudo ln -s namematching-20200214-lucene8 namematching
 - ls -laF
 - cd $TRAVIS_BUILD_DIR
 
 script:
-- "[ \"${TRAVIS_PULL_REQUEST}\" = \"false\" ] && mvn -P travis clean install deploy || mvn -P travis clean install"
+- 'if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then mvn -P travis clean install deploy; else mvn -P travis clean install; fi'
 
 env:
   global:

--- a/pom.xml
+++ b/pom.xml
@@ -11,8 +11,8 @@
     <artifactId>ala-name-matching</artifactId>
     <packaging>jar</packaging>
     <!-- Major version increment due to package structure change -->
-    <version>3.6-SNAPSHOT</version>
-    <name>ALA Name Matching (for Lucene 6 or above)</name>
+    <version>4.0-SNAPSHOT</version>
+    <name>ALA Name Matching (for Lucene 8 or above)</name>
     <!-- SCM entry that points to SVN directory that contains pom -->
     <scm>
         <connection>scm:git:git@github.com:AtlasOfLivingAustralia/ala-name-matching.git</connection>
@@ -23,7 +23,8 @@
     <properties>
         <!-- This project uses UTF8 for Regular Expressions -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <org.apache.lucene.version>6.6.5</org.apache.lucene.version>
+        <org.apache.lucene.version>8.1.0</org.apache.lucene.version>
+        <com.fasterxml.jackson.version>2.12.3</com.fasterxml.jackson.version>
         <targetJdk>1.8</targetJdk>
         <animal-sniffer-signature.artifact>java18</animal-sniffer-signature.artifact>
         <animal-sniffer-signature.version>1.0</animal-sniffer-signature.version>
@@ -146,17 +147,17 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.8.9</version>
+            <version>${com.fasterxml.jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.8.9</version>
+            <version>${com.fasterxml.jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.8.9</version>
+            <version>${com.fasterxml.jackson.version}</version>
         </dependency>
         <!-- For command line arg parsing -->
         <dependency>

--- a/src/main/java/au/org/ala/names/index/Taxonomy.java
+++ b/src/main/java/au/org/ala/names/index/Taxonomy.java
@@ -1659,7 +1659,7 @@ public class Taxonomy implements Reporter {
         IndexSearcher searcher = this.searcherManager.acquire();
         try {
             TopDocs docs = searcher.search(query, 100, Sort.INDEXORDER);
-            List<Map<Term, String>> valueList = new ArrayList<>(docs.totalHits);
+            List<Map<Term, String>> valueList = new ArrayList<>((int) docs.totalHits.value);
             for (ScoreDoc sd : docs.scoreDocs) {
                 Document document = searcher.doc(sd.doc);
                 Map<Term, String> values = new HashMap<>();

--- a/src/main/java/au/org/ala/names/lucene/analyzer/LowerCaseKeywordAnalyzer.java
+++ b/src/main/java/au/org/ala/names/lucene/analyzer/LowerCaseKeywordAnalyzer.java
@@ -19,9 +19,14 @@ import java.io.Reader;
 
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.core.KeywordTokenizer;
+import org.apache.lucene.analysis.core.KeywordTokenizerFactory;
 import org.apache.lucene.analysis.core.LowerCaseFilter;
 import org.apache.lucene.analysis.TokenStream;
+import org.apache.lucene.analysis.core.LowerCaseFilterFactory;
+import org.apache.lucene.analysis.custom.CustomAnalyzer;
 import org.apache.lucene.util.Version;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A custom KeywordAnalyzer that converts the text to lowercase before tokenizing
@@ -29,20 +34,20 @@ import org.apache.lucene.util.Version;
  *
  * @author Natasha
  */
-public final class LowerCaseKeywordAnalyzer extends Analyzer {
+public final class LowerCaseKeywordAnalyzer  {
+    private static final Logger logger = LoggerFactory.getLogger(LowerCaseKeywordAnalyzer.class);
 
-    @Override
-    protected TokenStreamComponents createComponents(String fieldName) {
-
-        KeywordTokenizer src = new KeywordTokenizer();
-        TokenStream result = new LowerCaseFilter(src);
-
-        return new TokenStreamComponents(src, result) {
-
-            @Override
-            protected void setReader(final Reader reader){
-                super.setReader(reader);
-            }
-        };
+    /**
+     * Get an instance of a lower-case keyword analyser.
+     *
+     * @return The analyser
+     */
+    public static Analyzer newInstance() {
+        try {
+            return CustomAnalyzer.builder().withTokenizer(KeywordTokenizerFactory.class).addTokenFilter(LowerCaseFilterFactory.class).build();
+        } catch (IOException ex) {
+            logger.error("Unable to build analyzer", ex);
+            throw new IllegalStateException(ex);
+        }
     }
-}
+ }

--- a/src/main/java/au/org/ala/names/search/ALANameSearcher.java
+++ b/src/main/java/au/org/ala/names/search/ALANameSearcher.java
@@ -105,7 +105,7 @@ public class ALANameSearcher {
         queryParser = new ThreadLocal<QueryParser>() {
             @Override
             protected QueryParser initialValue() {
-                QueryParser qp = new QueryParser("genus", new LowerCaseKeywordAnalyzer());
+                QueryParser qp = new QueryParser("genus", LowerCaseKeywordAnalyzer.newInstance());
                 qp.setFuzzyMinSim(0.8f); //fuzzy match similarity setting. used to match the authorship.
                 return qp;
             }
@@ -1513,7 +1513,7 @@ public class ALANameSearcher {
     private boolean isHomonymResolvable(LinnaeanRankClassification cl) {
         TopDocs results = getIRMNGGenus(cl, RankType.GENUS);
         if (results != null)
-            return results.totalHits <= 1;
+            return results.totalHits.value <= 1;
         return false;
     }
 
@@ -1562,7 +1562,7 @@ public class ALANameSearcher {
                 newcl.setSpecies(cl.getSpecies());
             if (cl != null && (cl.getGenus() != null || cl.getSpecies() != null)) {
                 TopDocs results = getIRMNGGenus(newcl, rank);
-                if (results == null || results.totalHits <= 1)
+                if (results == null || results.totalHits.value <= 1)
                     return null;
 
                 if (cl != null && cl.getKingdom() != null) {
@@ -1570,39 +1570,39 @@ public class ALANameSearcher {
                     newcl.setKingdom(cl.getKingdom());
                     //Step 1 search for kingdom and genus
                     results = getIRMNGGenus(newcl, rank);
-                    if (results.totalHits == 1)
+                    if (results.totalHits.value == 1)
                         return RankType.KINGDOM;
                 }
                 //Step 2 add the phylum
-                if (cl.getPhylum() != null && results.totalHits > 1) {
+                if (cl.getPhylum() != null && results.totalHits.value > 1) {
                     newcl.setPhylum(cl.getPhylum());
                     results = getIRMNGGenus(newcl, rank);
-                    if (results.totalHits == 1)
+                    if (results.totalHits.value == 1)
                         return RankType.PHYLUM;
                         //This may not be a good idea
-                    else if (results.totalHits == 0)
+                    else if (results.totalHits.value == 0)
                         newcl.setPhylum(null);//just in case the phylum was specified incorrectly
                 }
                 //Step 3 try the class
                 if (cl.getKlass() != null) {// && results.totalHits>1){
                     newcl.setKlass(cl.getKlass());
                     results = getIRMNGGenus(newcl, rank);
-                    if (results.totalHits == 1)
+                    if (results.totalHits.value == 1)
                         return RankType.CLASS;
 
                 }
                 //step 4 try order
-                if (cl.getOrder() != null && results.totalHits > 1) {
+                if (cl.getOrder() != null && results.totalHits.value > 1) {
                     newcl.setOrder(cl.getOrder());
                     results = getIRMNGGenus(newcl, rank);
-                    if (results.totalHits == 1)
+                    if (results.totalHits.value == 1)
                         return RankType.ORDER;
                 }
                 //step 5 try  the family
-                if (cl.getFamily() != null && results.totalHits > 1) {
+                if (cl.getFamily() != null && results.totalHits.value > 1) {
                     newcl.setFamily(cl.getFamily());
                     results = getIRMNGGenus(newcl, rank);
-                    if (results.totalHits == 1)
+                    if (results.totalHits.value == 1)
                         return RankType.FAMILY;
                 }
             }
@@ -1794,7 +1794,7 @@ public class ALANameSearcher {
             TermQuery tq = new TermQuery(new Term("lsid", lsid));
             try {
                 org.apache.lucene.search.TopDocs results = idSearcher.search(tq, 1);
-                if (results.totalHits > 0)
+                if (results.totalHits.value > 0)
                     return idSearcher.doc(results.scoreDocs[0].doc).get("reallsid");
             } catch (IOException e) {
             }
@@ -1808,9 +1808,9 @@ public class ALANameSearcher {
         try {
             Query query = new TermQuery(new Term(NameIndexField.LSID.toString(), lsid));
             TopDocs hits = this.idSearcher.search(query, 1);
-            if (hits.totalHits == 0)
+            if (hits.totalHits.value == 0)
                 hits = this.cbSearcher.search(query, 1);
-            if (hits.totalHits > 0)
+            if (hits.totalHits.value > 0)
                 return new NameSearchResult(cbSearcher.doc(hits.scoreDocs[0].doc), MatchType.TAXON_ID);
         } catch (Exception ex) {
             log.error("Unable to search for record by LSID " + lsid, ex);
@@ -2055,7 +2055,7 @@ public class ALANameSearcher {
             Query query = new TermQuery(new Term("concat_name", concatName));
 
             TopDocs topDocs = cbSearcher.search(query, 2);
-            if (topDocs != null && topDocs.totalHits == 1) {
+            if (topDocs != null && topDocs.totalHits.value == 1) {
                 for (ScoreDoc scoreDoc : topDocs.scoreDocs) {
                     Document doc = cbSearcher.doc(scoreDoc.doc);
                     return doc.get("guid");

--- a/src/main/java/au/org/ala/names/util/TermDump.java
+++ b/src/main/java/au/org/ala/names/util/TermDump.java
@@ -6,6 +6,8 @@ import org.apache.lucene.store.FSDirectory;
 import org.apache.lucene.util.BytesRef;
 
 import java.io.*;
+import java.util.HashSet;
+import java.util.Set;
 
 /**
  * Dump the terms in an index.
@@ -33,7 +35,11 @@ public class TermDump {
 
     public void dump() throws IOException {
         DirectoryReader reader = DirectoryReader.open(FSDirectory.open(this.index.toPath()));
-        Fields fields = MultiFields.getFields(reader);
+        Set<String> fields = new HashSet<>();
+        for (LeafReaderContext lc: reader.leaves()) {
+            for (FieldInfo fi: lc.reader().getFieldInfos())
+                fields.add(fi.name);
+        }
         PrintWriter pw = new PrintWriter(this.output);
 
         for (String field: fields) {

--- a/src/test/java/au/org/ala/names/search/ALANameSearcherTest.java
+++ b/src/test/java/au/org/ala/names/search/ALANameSearcherTest.java
@@ -20,7 +20,7 @@ public class ALANameSearcherTest {
 
     @org.junit.BeforeClass
     public static void init() throws Exception {
-        searcher = new ALANameSearcher("/data/lucene/namematching-20200214");
+        searcher = new ALANameSearcher("/data/lucene/namematching-20200214-lucene8");
     }
 
     @Test
@@ -1691,6 +1691,66 @@ public class ALANameSearcherTest {
         assertEquals("https://id.biodiversity.org.au/node/apni/2916208", metrics.getResult().getAcceptedLsid());
         assertEquals(MatchType.EXACT, metrics.getResult().getMatchType());
         assertTrue(metrics.getErrors().contains(ErrorType.MATCH_MISAPPLIED));
+    }
+
+
+    // Higher taxonomy only filled out
+    @Test
+    public void testHigherTaxonomy() throws Exception {
+        String family = "Pterophoridae";
+        LinnaeanRankClassification cl = new LinnaeanRankClassification();
+        cl.setFamily(family);
+        MetricsResultDTO metrics = searcher.searchForRecordMetrics(cl, true);
+        assertNotNull(metrics);
+        assertEquals("NZOR-6-49519", metrics.getResult().getLsid());
+        assertEquals(RankType.FAMILY, metrics.getResult().getRank());
+        assertEquals(MatchType.EXACT, metrics.getResult().getMatchType());
+    }
+
+    // Phrase name with rank marker
+    @Test
+    public void testPhraseName1() throws Exception {
+        String name = "Tephrosia sp. Crowded pinnae (C.R.Dunlop 8202)";
+        String kingdom = "Planate";
+        String phylum = "Streptophyta";
+        String class_ = "Equisetopsida";
+        String order = "Fabales";
+        String genus = "Tephrosia";
+        String specificEpithet = "sp. Crowded pinnae (C.R.Dunlop 8202)";
+        String rank = "species";
+        LinnaeanRankClassification cl = new LinnaeanRankClassification();
+        cl.setKingdom(kingdom);
+        cl.setPhylum(phylum);
+        cl.setKlass(class_);
+        cl.setOrder(order);
+        cl.setGenus(genus);
+        cl.setSpecificEpithet(specificEpithet);
+        //cl.setRank(rank);
+        cl.setScientificName(name);
+        MetricsResultDTO metrics = searcher.searchForRecordMetrics(cl, true);
+        assertNotNull(metrics);
+        assertEquals("https://id.biodiversity.org.au/instance/apni/932722", metrics.getResult().getLsid());
+        assertEquals("https://id.biodiversity.org.au/node/apni/2890778", metrics.getResult().getAcceptedLsid());
+        assertEquals(MatchType.EXACT, metrics.getResult().getMatchType());
+    }
+
+    @Test
+    public void testPhraseName2() throws Exception {
+        String name = "Tephrosia sp. Miriam Vale (E.J.Thompson+ MIR33)";
+        String kingdom = "Planate";
+        String class_ = "Equisetopsida";
+        String genus = "Tephrosia";
+         String rank = "species";
+        LinnaeanRankClassification cl = new LinnaeanRankClassification();
+        cl.setKingdom(kingdom);
+        cl.setKlass(class_);
+        cl.setGenus(genus);
+        //cl.setRank(rank);
+        cl.setScientificName(name);
+        MetricsResultDTO metrics = searcher.searchForRecordMetrics(cl, true);
+        assertNotNull(metrics);
+        assertEquals("https://id.biodiversity.org.au/node/apni/2903953", metrics.getResult().getLsid());
+        assertEquals(MatchType.PHRASE, metrics.getResult().getMatchType());
     }
 
 }

--- a/src/test/java/au/org/ala/names/search/BiocacheMatchTest.java
+++ b/src/test/java/au/org/ala/names/search/BiocacheMatchTest.java
@@ -22,7 +22,7 @@ public class BiocacheMatchTest {
 
     @org.junit.BeforeClass
     public static void init() throws Exception {
-        searcher = new ALANameSearcher("/data/lucene/namematching-20200214");
+        searcher = new ALANameSearcher("/data/lucene/namematching-20200214-lucene8");
     }
 
     @Test

--- a/src/test/java/au/org/ala/names/search/IconicSpeciesTest.java
+++ b/src/test/java/au/org/ala/names/search/IconicSpeciesTest.java
@@ -30,7 +30,7 @@ public class IconicSpeciesTest {
 
     @org.junit.BeforeClass
     public static void init() throws Exception {
-        searcher = new ALANameSearcher("/data/lucene/namematching-20200214");
+        searcher = new ALANameSearcher("/data/lucene/namematching-20200214-lucene8");
     }
 
     //@Test

--- a/src/test/java/au/org/ala/names/search/VernacularMatchTest.java
+++ b/src/test/java/au/org/ala/names/search/VernacularMatchTest.java
@@ -24,7 +24,7 @@ public class VernacularMatchTest {
 
     @org.junit.BeforeClass
     public static void init() throws Exception {
-        searcher = new ALANameSearcher("/data/lucene/namematching-20200214");
+        searcher = new ALANameSearcher("/data/lucene/namematching-20200214-lucene8");
      }
 
     @Test


### PR DESCRIPTION
Bump development version to a new major revision to associate with new Lucene version
Update travis to use the new index.
Note that the -lucene8 index does not have the same left- and right-values as the production index. It's for testing only.