### PR TITLE
Allow merging of Chromista/Protozoa/Protista despite differing nomenclatural codes.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,10 @@ branches:
 
 before_install:
 - mkdir -p ~/.m2; wget -q -O ~/.m2/settings.xml https://raw.githubusercontent.com/AtlasOfLivingAustralia/travis-build-configuration/master/travis_maven_settings_simple.xml
-- sudo mkdir -p /data/lucene; sudo wget -O /data/lucene/namematching-20210811.tgz https://archives.ala.org.au/archives/nameindexes/20210811/namematching-20210811.tgz
+- sudo mkdir -p /data/lucene; sudo wget -O /data/lucene/namematching-20210811-2.tgz https://archives.ala.org.au/archives/nameindexes/20210811-2/namematching-20210811-2.tgz
 - cd /data/lucene
-- sudo tar zxvf namematching-20210811.tgz
-- sudo ln -s namematching-20210811 namematching
+- sudo tar zxvf namematching-20210811-2.tgz
+- sudo ln -s namematching-20210811-2 namematching
 - ls -laF
 - cd $TRAVIS_BUILD_DIR
 

--- a/README.md
+++ b/README.md
@@ -102,8 +102,8 @@ Each module contains two artefacts in the
 * ala-name-matching-<module>-4.0-SNAPSHOT.jar - built jar for the project code only
 * ala-name-matching-<module>-4.0-SNAPSHOT-sources.jar - source jar for the project code only
 
-The name index for Australian names lists used in unit tests can be downloaded [from here](https://biocache.ala.org.au/archives/nameindexes/20220629) and needs to be extracted to the
-directory `/data/lucene/namematching-20210811`
+The name index for Australian names lists used in unit tests can be downloaded [from here](https://biocache.ala.org.au/archives/nameindexes/20210811-2) and needs to be extracted to the
+directory `/data/lucene/namematching-20210811-2`
 
 ## ALA Names List
 

--- a/ala-name-matching-builder/src/main/java/au/org/ala/names/index/CSVNameSource.java
+++ b/ala-name-matching-builder/src/main/java/au/org/ala/names/index/CSVNameSource.java
@@ -17,6 +17,7 @@
 package au.org.ala.names.index;
 
 import au.org.ala.names.model.RankType;
+import au.org.ala.names.model.TaxonFlag;
 import au.org.ala.names.model.TaxonomicType;
 import au.org.ala.vocab.ALATerm;
 import com.opencsv.CSVReader;
@@ -28,7 +29,6 @@ import org.apache.lucene.document.StringField;
 import org.gbif.api.model.registry.Citation;
 import org.gbif.api.model.registry.Contact;
 import org.gbif.api.vocabulary.Country;
-import org.gbif.api.vocabulary.NomenclaturalCode;
 import org.gbif.api.vocabulary.NomenclaturalStatus;
 import org.gbif.dwc.terms.*;
 import org.slf4j.Logger;
@@ -211,6 +211,7 @@ public class CSVNameSource extends NameSource {
         Integer acceptedNameUsageIDIndex = termLocations.get(DwcTerm.acceptedNameUsageID);
         Integer taxonRemarksIndex = termLocations.get(DwcTerm.taxonRemarks);
         Integer provenanceIndex = termLocations.get(DcTerm.provenance);
+        Integer taxonomicFlagsIndex = termLocations.get(ALATerm.taxonomicFlags);
         Set<Term> classifications = TaxonConceptInstance.CLASSIFICATION_FIELDS.stream().filter(t -> termLocations.containsKey(t)).collect(Collectors.toSet());
         try {
             String[] r;
@@ -219,7 +220,7 @@ public class CSVNameSource extends NameSource {
                 final String[] record = r;
                 String taxonID = this.get(record, taxonIDIndex);
                 String verbatimNomenclautralCode = this.get(record, nomenclaturalCodeIndex);
-                NomenclaturalCode code = taxonomy.resolveCode(verbatimNomenclautralCode);
+                NomenclaturalClassifier code = taxonomy.resolveCode(verbatimNomenclautralCode);
                 NameProvider provider = taxonomy.resolveProvider(this.get(record, datasetIDIndex), this.get(record, datasetNameIndex));
                 String scientificName = this.get(record, scientificNameIndex);
                 String scientificNameAuthorship = this.get(record, scientificNameAuthorshipIndex);
@@ -231,6 +232,8 @@ public class CSVNameSource extends NameSource {
                 RankType rank = taxonomy.resolveRank(verbatimTaxonRank);
                 String verbatimNomenclaturalStatus = this.get(record, nomenclaturalStatusIndex);
                 Set<NomenclaturalStatus> nomenclaturalStatus = taxonomy.resolveNomenclaturalStatus(verbatimNomenclaturalStatus);
+                String verbatimTaxonomicFlags = this.get(record, taxonomicFlagsIndex);
+                Set<TaxonFlag> flags = taxonomy.resolveTaxonomicFlags(verbatimTaxonomicFlags);
                 String parentNameUsage = this.get(record, parentNameUsageIndex);
                 String parentNameUsageID = this.get(record, parentNameUsageIDIndex);
                 String acceptedNameUsage = this.get(record, acceptedNameUsageIndex);
@@ -265,7 +268,8 @@ public class CSVNameSource extends NameSource {
                         taxonRemarks,
                         verbatimTaxonRemarks,
                         provenance,
-                        classification);
+                        classification,
+                        flags);
                 instance.normalise();
                 instance = taxonomy.addInstance(instance);
                 Document doc = new Document();

--- a/ala-name-matching-builder/src/main/java/au/org/ala/names/index/DwcaNameSource.java
+++ b/ala-name-matching-builder/src/main/java/au/org/ala/names/index/DwcaNameSource.java
@@ -17,6 +17,7 @@
 package au.org.ala.names.index;
 
 import au.org.ala.names.model.RankType;
+import au.org.ala.names.model.TaxonFlag;
 import au.org.ala.names.model.TaxonomicType;
 import au.org.ala.names.model.VernacularType;
 import au.org.ala.vocab.ALATerm;
@@ -266,7 +267,7 @@ public class DwcaNameSource extends NameSource {
                 if (datasetName == null)
                     datasetName = defaultDatasetName;
                 NameProvider provider = taxonomy.resolveProvider(core.value(DwcTerm.datasetID), datasetName);
-                NomenclaturalCode code = taxonomy.resolveCode(verbatimNomenclaturalCode);
+                NomenclaturalClassifier code = taxonomy.resolveCode(verbatimNomenclaturalCode);
                 String scientificName = core.value(DwcTerm.scientificName);
                 String scientificNameAuthorship = core.value(DwcTerm.scientificNameAuthorship);
                 String nameComplete = core.value(ALATerm.nameComplete);
@@ -292,8 +293,10 @@ public class DwcaNameSource extends NameSource {
                 String acceptedNameUsageID = core.value(DwcTerm.acceptedNameUsageID);
                 String verbatimTaxonRemarks = core.value(DwcTerm.taxonRemarks);
                 String verbatimProvenance = core.value(DcTerm.provenance);
+                String taxonomicFlags = core.value(ALATerm.taxonomicFlags);
                 List<String> taxonRemarks = verbatimTaxonRemarks == null || verbatimTaxonRemarks.isEmpty() ? null : Arrays.stream(verbatimTaxonRemarks.split("\\|")).map(s -> s.trim()).collect(Collectors.toList());
                 List<String> provenance = verbatimProvenance == null || verbatimProvenance.isEmpty() ? null : Arrays.stream(verbatimProvenance.split("\\|")).map(s -> s.trim()).collect(Collectors.toList());
+                Set<TaxonFlag> flags = taxonomy.resolveTaxonomicFlags(taxonomicFlags);
                 Map<Term, Optional<String>> classification = classifiers.stream().collect(Collectors.toMap(t -> t, t -> Optional.ofNullable(core.value(t))));
                 TaxonConceptInstance instance = new TaxonConceptInstance(
                         taxonID,
@@ -317,7 +320,8 @@ public class DwcaNameSource extends NameSource {
                         taxonRemarks,
                         verbatimTaxonRemarks,
                         provenance,
-                        classification);
+                        classification,
+                        flags);
                 instance = taxonomy.addInstance(instance);
 
                 List<Document> docs = new ArrayList<>();
@@ -349,7 +353,7 @@ public class DwcaNameSource extends NameSource {
      *
      * @throws Exception if unable to load the pseudo-taxon
      */
-    private void addPseudoTaxon(Taxonomy taxonomy, Record record, String taxonID, NomenclaturalCode code) throws Exception {
+    private void addPseudoTaxon(Taxonomy taxonomy, Record record, String taxonID, NomenclaturalClassifier code) throws Exception {
         if (record.rowType().equals(GbifTerm.VernacularName)) {
             String vernacularName = record.value(DwcTerm.vernacularName);
             String status = record.value(ALATerm.status);
@@ -376,6 +380,7 @@ public class DwcaNameSource extends NameSource {
                         null,
                         null,
                         taxonID,
+                        null,
                         null,
                         null,
                         null,

--- a/ala-name-matching-builder/src/main/java/au/org/ala/names/index/NameAnalyser.java
+++ b/ala-name-matching-builder/src/main/java/au/org/ala/names/index/NameAnalyser.java
@@ -17,8 +17,8 @@
 package au.org.ala.names.index;
 
 import au.org.ala.names.model.RankType;
+import au.org.ala.names.model.TaxonFlag;
 import au.org.ala.names.model.TaxonomicType;
-import org.gbif.api.vocabulary.NomenclaturalCode;
 import org.gbif.api.vocabulary.NomenclaturalStatus;
 import org.gbif.checklistbank.authorship.AuthorComparator;
 import org.gbif.checklistbank.model.Equality;
@@ -29,6 +29,7 @@ import javax.annotation.Nullable;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Work out the indexable details of a name.
@@ -63,16 +64,16 @@ abstract public class NameAnalyser implements Comparator<NameKey>, Reporter {
      * Convienience method for testing.
      */
     public NameKey analyse(TaxonConceptInstance instance) {
-        return this.analyse(instance.getCode(), instance.getScientificName(), instance.getScientificNameAuthorship(), instance.getRank(), instance.getTaxonomicStatus(), false);
+        return this.analyse(instance.getCode(), instance.getScientificName(), instance.getScientificNameAuthorship(), instance.getRank(), instance.getTaxonomicStatus(), instance.getFlags(), false);
     }
 
     /**
      * Convienience method for testing.
      */
     public NameKey analyse(String code, String scientificName, String scientificNameAuthorship, String rank) {
-        NomenclaturalCode canonicalCode = this.canonicaliseCode(code);
+        NomenclaturalClassifier canonicalCode = this.canonicaliseCode(code);
         RankType rankType = this.canonicaliseRank(rank);
-        return this.analyse(canonicalCode, scientificName, scientificNameAuthorship, rankType, null, false);
+        return this.analyse(canonicalCode, scientificName, scientificNameAuthorship, rankType, null, null, false);
     }
 
     /**
@@ -91,7 +92,7 @@ abstract public class NameAnalyser implements Comparator<NameKey>, Reporter {
      *
      * @return A suitable name key
      */
-    abstract public NameKey analyse(@Nullable NomenclaturalCode code, String scientificName, @Nullable String scientificNameAuthorship, @Nullable RankType rankType, @Nullable TaxonomicType taxonomicStatus, boolean loose);
+    abstract public NameKey analyse(@Nullable NomenclaturalClassifier code, String scientificName, @Nullable String scientificNameAuthorship, @Nullable RankType rankType, @Nullable TaxonomicType taxonomicStatus, @Nullable Set<TaxonFlag> flags, boolean loose);
 
     /**
      * Set the issue reporter.
@@ -109,7 +110,7 @@ abstract public class NameAnalyser implements Comparator<NameKey>, Reporter {
      *
      * @return The canonicalised code
      */
-    abstract public NomenclaturalCode canonicaliseCode(String code);
+    abstract public NomenclaturalClassifier canonicaliseCode(String code);
 
     /**
      * Canonicalise the taxonomic status
@@ -139,6 +140,15 @@ abstract public class NameAnalyser implements Comparator<NameKey>, Reporter {
     abstract public NomenclaturalStatus canonicaliseNomenclaturalStatus(String nomenclaturalStatus);
 
     /**
+     * Canonicalise a supplied taxonomic flag
+     *
+     * @param flag The flag name
+     *
+     * @return The matching flag
+     */
+    abstract public TaxonFlag canonicaliseFlag(String flag);
+
+    /**
      * Test for an informal name.
      * <p>
      *
@@ -153,6 +163,7 @@ abstract public class NameAnalyser implements Comparator<NameKey>, Reporter {
      * Compare two keys.
      * <p>
      *     Comparison is equal if the codes, names and authors are equal.
+     *     Name keys with fuzzy nomenclatural codes do not compare codes.
      *     Authorship equality is decided by a {@link AuthorComparator}
      *     which can get a wee bit complicated.
      * </p>
@@ -169,8 +180,10 @@ abstract public class NameAnalyser implements Comparator<NameKey>, Reporter {
             return -1;
         if (key1.getCode() != null && key2.getCode() == null)
             return 1;
-        if (key1.getCode() != null && key2.getCode() != null && (cmp = key1.getCode().compareTo(key2.getCode())) != 0)
-            return cmp;
+        if (key1.getCode() != null && key2.getCode() != null) {
+            if ((cmp = key1.getCode().compareTo(key2.getCode())) != 0)
+                return cmp;
+        }
         if ((cmp = key1.getScientificName().compareTo(key2.getScientificName())) != 0)
             return cmp;
         if ((cmp = key1.getRank().compareTo(key2.getRank())) != 0)

--- a/ala-name-matching-builder/src/main/java/au/org/ala/names/index/NameKey.java
+++ b/ala-name-matching-builder/src/main/java/au/org/ala/names/index/NameKey.java
@@ -24,10 +24,9 @@ package au.org.ala.names.index;
  * @copyright Copyright (c) 2017 CSIRO
  */
 
-import au.org.ala.names.model.NameFlag;
+import au.org.ala.names.model.TaxonFlag;
 import au.org.ala.names.model.RankType;
 import org.gbif.api.vocabulary.NameType;
-import org.gbif.api.vocabulary.NomenclaturalCode;
 
 import javax.annotation.Nullable;
 import java.util.HashSet;
@@ -37,7 +36,7 @@ public class NameKey implements Comparable<NameKey> {
     /** The analyser to use for comparisons */
     private NameAnalyser analyser;
     /** The nomenclatural code for scientific names */
-    private NomenclaturalCode code;
+    private NomenclaturalClassifier code;
     /** The scientific name */
     private String scientificName;
     /** The authorship */
@@ -48,7 +47,7 @@ public class NameKey implements Comparable<NameKey> {
     private NameType type;
     /** Special case flags for a name */
     @Nullable
-    private Set<NameFlag> flags;
+    private Set<TaxonFlag> flags;
 
     /**
      * Construct a name key
@@ -61,7 +60,7 @@ public class NameKey implements Comparable<NameKey> {
      * @param type The type of name
      * @param flags Any name flags (null for none)
      */
-    public NameKey(NameAnalyser analyser, NomenclaturalCode code, String scientificName, String scientificNameAuthorship, RankType rank, NameType type, @Nullable Set<NameFlag> flags) {
+    public NameKey(NameAnalyser analyser, NomenclaturalClassifier code, String scientificName, String scientificNameAuthorship, RankType rank, NameType type, @Nullable Set<TaxonFlag> flags) {
         this.analyser = analyser;
         this.code = code;
         this.scientificName = scientificName;
@@ -88,7 +87,7 @@ public class NameKey implements Comparable<NameKey> {
      *
      * @return The normenclatural code
      */
-    public NomenclaturalCode getCode() {
+    public NomenclaturalClassifier getCode() {
         return code;
     }
 
@@ -130,8 +129,17 @@ public class NameKey implements Comparable<NameKey> {
      * @return Any name flags for this name, null for none
      */
     @Nullable
-    public Set<NameFlag> getFlags() {
-        return flags;
+    public Set<TaxonFlag> getFlags() {
+        return this.flags;
+    }
+
+    /**
+     * Check to see if this key has a flag.
+     * @param flag
+     * @return
+     */
+    public boolean hasFlag(TaxonFlag flag) {
+        return this.flags != null && this.flags.contains(flag);
     }
 
     /**
@@ -140,7 +148,7 @@ public class NameKey implements Comparable<NameKey> {
      * @return True if the name is an autonym (and therefore doesn't have an author
      */
     public boolean isAutonym() {
-        return flags != null && flags.contains(NameFlag.AUTONYM);
+        return this.hasFlag(TaxonFlag.AUTONYM);
     }
 
     /**
@@ -221,10 +229,10 @@ public class NameKey implements Comparable<NameKey> {
     public NameKey toNameKey() {
         if (this.scientificNameAuthorship == null)
             return this;
-        Set<NameFlag> fl = this.flags;
-        if (fl != null && fl.contains(NameFlag.AUTONYM)) {
+        Set<TaxonFlag> fl = this.flags;
+        if (fl != null && fl.contains(TaxonFlag.AUTONYM)) {
             fl = new HashSet<>(this.flags);
-            fl.remove(NameFlag.AUTONYM);
+            fl.remove(TaxonFlag.AUTONYM);
             fl = fl.isEmpty() ? null : fl;
 
         }
@@ -239,10 +247,10 @@ public class NameKey implements Comparable<NameKey> {
     public NameKey toUnrankedNameKey() {
         if (this.scientificNameAuthorship == null && this.rank == RankType.UNRANKED)
             return this;
-        Set<NameFlag> fl = this.flags;
-        if (fl != null && fl.contains(NameFlag.AUTONYM)) {
+        Set<TaxonFlag> fl = this.flags;
+        if (fl != null && fl.contains(TaxonFlag.AUTONYM)) {
             fl = new HashSet<>(this.flags);
-            fl.remove(NameFlag.AUTONYM);
+            fl.remove(TaxonFlag.AUTONYM);
             fl = fl.isEmpty() ? null : fl;
 
         }
@@ -271,10 +279,10 @@ public class NameKey implements Comparable<NameKey> {
     public NameKey toUncodedNameKey() {
         if (this.scientificNameAuthorship == null && this.rank == RankType.UNRANKED && this.code == null)
             return this;
-        Set<NameFlag> fl = this.flags;
-        if (fl != null && fl.contains(NameFlag.AUTONYM)) {
+        Set<TaxonFlag> fl = this.flags;
+        if (fl != null && fl.contains(TaxonFlag.AUTONYM)) {
             fl = new HashSet<>(this.flags);
-            fl.remove(NameFlag.AUTONYM);
+            fl.remove(TaxonFlag.AUTONYM);
             fl = fl.isEmpty() ? null : fl;
 
         }

--- a/ala-name-matching-builder/src/main/java/au/org/ala/names/index/NameProvider.java
+++ b/ala-name-matching-builder/src/main/java/au/org/ala/names/index/NameProvider.java
@@ -19,7 +19,6 @@ package au.org.ala.names.index;
 import au.org.ala.names.index.provider.*;
 import com.fasterxml.jackson.annotation.*;
 import org.gbif.api.model.registry.Citation;
-import org.gbif.api.vocabulary.NomenclaturalCode;
 import org.gbif.dwc.terms.DcTerm;
 import org.gbif.dwc.terms.DwcTerm;
 import org.gbif.dwc.terms.Term;
@@ -84,7 +83,7 @@ public class NameProvider {
     private KeyAdjuster keyAdjuster;
     /** The default nomenclatural code */
     @JsonProperty
-    private NomenclaturalCode defaultNomenclaturalCode;
+    private NomenclaturalClassifier defaultNomenclaturalCode;
     /** Is this a "loose" taxonomy, where we can expect fragments of taxonomy and we shouldn't worry too much about consistency */
     @JsonProperty
     private boolean loose;
@@ -465,7 +464,7 @@ public class NameProvider {
      * </p>
      */
     @JsonIgnore
-    public NomenclaturalCode getDefaultNomenclaturalCode() {
+    public NomenclaturalClassifier getDefaultNomenclaturalCode() {
         if (this.defaultNomenclaturalCode != null)
             return this.defaultNomenclaturalCode;
         if (this.parent != null)
@@ -675,7 +674,7 @@ public class NameProvider {
      * @throws IndexBuilderException if unable to detect a parent
      */
     public TaxonomicElement findDefaultParent(Taxonomy taxonomy, TaxonConceptInstance instance) throws IndexBuilderException {
-        NomenclaturalCode code = instance.getCode();
+        NomenclaturalClassifier code = instance.getCode();
         String dp = this.getDefaultParentTaxon();
 
         if (code == null || dp == null)

--- a/ala-name-matching-builder/src/main/java/au/org/ala/names/index/NameSource.java
+++ b/ala-name-matching-builder/src/main/java/au/org/ala/names/index/NameSource.java
@@ -79,7 +79,8 @@ abstract public class NameSource {
             DwcTerm.namePublishedInYear,
             DcTerm.source,
             DwcTerm.taxonRemarks,
-            DcTerm.provenance
+            DcTerm.provenance,
+            ALATerm.taxonomicFlags
     );
     /** Terms not to be included in taxon outputs */
     protected static final List<Term> TAXON_FORBIDDEN = Arrays.asList(

--- a/ala-name-matching-builder/src/main/java/au/org/ala/names/index/NomenclaturalClassifier.java
+++ b/ala-name-matching-builder/src/main/java/au/org/ala/names/index/NomenclaturalClassifier.java
@@ -1,0 +1,305 @@
+/*
+ * Copyright (c) 2021 Atlas of Living Australia
+ * All Rights Reserved.
+ *
+ * The contents of this file are subject to the Mozilla Public
+ * License Version 1.1 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.mozilla.org/MPL/
+ *
+ * Software distributed under the License is distributed on an "AS
+ *  IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ */
+
+package au.org.ala.names.index;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+import com.opencsv.CSVReader;
+import com.opencsv.CSVReaderBuilder;
+import org.apache.commons.lang3.StringUtils;
+import org.gbif.api.vocabulary.NomenclaturalCode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.net.URL;
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+/**
+ * Nomenclatural code classification.
+ * <p>
+ * Used instead of the GBIF NomenclaturalClassifier to allow navigation
+ * of fuzzy code matching.
+ * </p>
+ */
+@JsonSerialize(using = NomenclaturalClassifier.Serializer.class)
+@JsonDeserialize(using = NomenclaturalClassifier.Deserializer.class)
+public class NomenclaturalClassifier implements Comparable<NomenclaturalClassifier> {
+    private static final Logger logger = LoggerFactory.getLogger(NomenclaturalClassifier.class);
+
+    private String acronym;
+    private String title;
+    private URL source;
+    private NomenclaturalClassifier parent;
+    private NomenclaturalCode code;
+    private Set<String> aliases;
+
+    /** The list of instances */
+    private final static List<NomenclaturalClassifier> CLASSIFIERS = buildInstances();
+    /** The parsing map */
+    private final static Map<String, NomenclaturalClassifier> NAMES = buildNames(CLASSIFIERS);
+    /** The GBIF code map */
+    private final static Map<NomenclaturalCode, NomenclaturalClassifier> CODES = CLASSIFIERS.stream()
+            .filter(c -> c.getCode() != null)
+            .collect(Collectors.toMap(
+                    NomenclaturalClassifier::getCode,
+                    c -> c)
+            );
+
+    /** The bacterial classifier */
+    public static final NomenclaturalClassifier BACTERIAL = find(NomenclaturalCode.BACTERIAL);
+    /** The botanical classifier */
+    public static final NomenclaturalClassifier BOTANICAL = find(NomenclaturalCode.BOTANICAL);
+    /** The cultivar classifier */
+    public static final NomenclaturalClassifier CULTIVARS = find(NomenclaturalCode.CULTIVARS);
+    /** The virus classifier */
+    public static final NomenclaturalClassifier VIRUS = find(NomenclaturalCode.VIRUS);
+    /** The zoological classifier */
+    public static final NomenclaturalClassifier ZOOLOGICAL = find(NomenclaturalCode.ZOOLOGICAL);
+
+
+    /**
+     * Read the list of instances from a file
+     *
+     * @return The instance list
+     */
+    private static List<NomenclaturalClassifier> buildInstances() {
+        try {
+            Reader r = new InputStreamReader(NomenclaturalClassifier.class.getResourceAsStream("nomenclatural_classifiers.csv"), "UTF-8");
+            CSVReader reader = new CSVReaderBuilder(r).withSkipLines(1).build();
+            List<NomenclaturalClassifier> classifiers = new ArrayList<>();
+            for (String[] row: reader) {
+                String acronym = row[0];
+                final String p = StringUtils.trimToNull(row[1]);
+                NomenclaturalClassifier parent = p == null ? null : classifiers.stream()
+                        .filter(c -> c.getAcronym().equals(p))
+                        .findFirst()
+                        .orElseThrow(() -> new IllegalArgumentException("Can't find parent " + p));
+                String title = row[2];
+                String s = StringUtils.trimToNull(row[3]);
+                URL source = s == null ? null : new URL(s);
+                String c = StringUtils.trimToNull(row[4]);
+                NomenclaturalCode code = c == null ? null : NomenclaturalCode.valueOf(c);
+                Set<String> aliases = IntStream.range(5, row.length).mapToObj(i -> row[i]).collect(Collectors.toSet());
+                classifiers.add(new NomenclaturalClassifier(acronym, parent, title, source, code, aliases));
+            }
+            return classifiers;
+        } catch (Exception ex) {
+            throw new IllegalStateException("Unable to read nomenclatural codes", ex);
+        }
+    }
+
+    /**
+     * Create a parsing map for the classifiers
+     *
+     * @param classifiers The list of classifiers
+     *
+     * @return The parsing map
+     */
+    private static Map<String, NomenclaturalClassifier> buildNames(List<NomenclaturalClassifier> classifiers) {
+        Map<String, NomenclaturalClassifier> map = new HashMap<>();
+        for (NomenclaturalClassifier classifier: classifiers) {
+            map.put(classifier.getAcronym(), classifier);
+            if (classifier.getCode() != null)
+                map.put(classifier.getCode().name(), classifier);
+            for (String alias: classifier.getAliases())
+                map.put(alias, classifier);
+
+        }
+        return map;
+    }
+
+    /**
+     * Find a nomenclatural classifier
+     *
+     * @param code The code
+     *
+     * @return The classifier, or null for not found
+     */
+    public static NomenclaturalClassifier find(String code) {
+        return NAMES.get(code);
+    }
+
+    /**
+     * Find a nomenclatural classifier
+     *
+     * @param code The code
+     *
+     * @return The classifier, or null for not found
+     */
+    public static NomenclaturalClassifier find(NomenclaturalCode code) {
+        return CODES.get(code);
+    }
+
+    /**
+     * Construct a new classifier
+     *
+     * @param acronym The standard acronym for the code
+     * @param parent Any parent classification
+     * @param title The full title of the classificartion
+     * @param source A source URL
+     * @param code The matchng GBIF nomenclatural code
+     * @param aliases Any aliases
+     */
+    protected NomenclaturalClassifier(String acronym, NomenclaturalClassifier parent, String title, URL source, NomenclaturalCode code, Set<String> aliases) {
+        this.acronym = acronym;
+        this.parent = parent;
+        this.title = title;
+        this.source = source;
+        this.code = code;
+        this.aliases = aliases;
+    }
+
+    /**
+     * Get the preferred code acronym.
+     *
+     * @return The code
+     */
+    public String getAcronym() {
+        return acronym;
+    }
+
+    /**
+     * Get the full title of the code.
+     *
+     * @return The title
+     */
+    public String getTitle() {
+        return title;
+    }
+
+    /**
+     * Get the code source URL
+     *
+     * @return The source
+     */
+    public URL getSource() {
+        return source;
+    }
+
+    /**
+     * Get the parent code
+     *
+     * @return The parent code
+     */
+    public NomenclaturalClassifier getParent() {
+        return parent;
+    }
+
+    /**
+     * Get the GBIF nomenclatural code
+     *
+     * @return
+     */
+    public NomenclaturalCode getCode() {
+        return code;
+    }
+
+    /**
+     * Get any aliases that this code goes under
+     *
+     * @return
+     */
+    public Set<String> getAliases() {
+        return aliases;
+    }
+
+    /**
+     * Two classifiers are equal if they have the same acronym.
+     *
+     * @param o The other object
+     *
+     * @return True if equal, false otherwise
+     */
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        NomenclaturalClassifier that = (NomenclaturalClassifier) o;
+        return acronym.equals(that.acronym);
+    }
+
+    /**
+     * Has based on acronym
+     *
+     * @return The has code
+     */
+    @Override
+    public int hashCode() {
+        return Objects.hash(acronym);
+    }
+
+    /**
+     * String representation
+     *
+     * @return The acronym
+     */
+    @Override
+    public String toString() {
+        return this.acronym;
+    }
+
+    /**
+     * Compare acronyms
+     *
+     * @param o The other classifier
+     *
+     * @return An ordewring based on the acrobym
+     */
+    @Override
+    public int compareTo(NomenclaturalClassifier o) {
+        return this.acronym.compareTo(o.acronym);
+    }
+
+    public static class Serializer extends StdSerializer<NomenclaturalClassifier> {
+        public Serializer() {
+            super(NomenclaturalClassifier.class);
+        }
+
+        @Override
+        public void serialize(NomenclaturalClassifier value, JsonGenerator gen, SerializerProvider provider) throws IOException {
+            if (value != null) {
+                gen.writeString(value.getAcronym());
+            }
+        }
+    }
+
+    public static class Deserializer extends StdDeserializer<NomenclaturalClassifier> {
+        public Deserializer() {
+            super(NomenclaturalClassifier.class);
+        }
+
+         @Override
+        public NomenclaturalClassifier deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+             String code = p.getValueAsString();
+             NomenclaturalClassifier classifier = NomenclaturalClassifier.find(code);
+             if (classifier == null)
+                 throw new IllegalArgumentException("Unrecognised nomenclatural code " + code);
+             return classifier;
+        }
+    }
+}

--- a/ala-name-matching-builder/src/main/java/au/org/ala/names/index/TaxonConceptInstance.java
+++ b/ala-name-matching-builder/src/main/java/au/org/ala/names/index/TaxonConceptInstance.java
@@ -17,12 +17,12 @@
 package au.org.ala.names.index;
 
 import au.org.ala.names.model.RankType;
+import au.org.ala.names.model.TaxonFlag;
 import au.org.ala.names.model.TaxonomicType;
 import au.org.ala.vocab.ALATerm;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.StringField;
-import org.gbif.api.vocabulary.NomenclaturalCode;
 import org.gbif.api.vocabulary.NomenclaturalStatus;
 import org.gbif.dwc.terms.DcTerm;
 import org.gbif.dwc.terms.DwcTerm;
@@ -127,7 +127,7 @@ public class TaxonConceptInstance extends TaxonomicElement<TaxonConceptInstance,
     /** The taxon identifier */
     private String taxonID;
     /** The nomenclatural code */
-    private NomenclaturalCode code;
+    private NomenclaturalClassifier code;
     /** The supplied nomenclatural code */
     private String verbatimNomenclaturalCode;
     /** The name source */
@@ -173,6 +173,8 @@ public class TaxonConceptInstance extends TaxonomicElement<TaxonConceptInstance,
     private TaxonomicElement accepted;
     /** Additional classification information */
     private Map<Term, Optional<String>> classification;
+    /** Any special flags */
+    private Set<TaxonFlag> flags;
     /** The base score for position on the taxonomic tree */
     private Integer baseScore;
     /** The specific instance score */
@@ -208,7 +210,7 @@ public class TaxonConceptInstance extends TaxonomicElement<TaxonConceptInstance,
      */
     public TaxonConceptInstance(
             String taxonID,
-            NomenclaturalCode code,
+            NomenclaturalClassifier code,
             String verbatimNomenclaturalCode,
             NameProvider provider,
             String scientificName,
@@ -228,7 +230,8 @@ public class TaxonConceptInstance extends TaxonomicElement<TaxonConceptInstance,
             @Nullable List<String> taxonRemarks,
             @Nullable String verbatimTaxonRemarks,
             @Nullable List<String> provenance,
-            @Nullable Map<Term, Optional<String>> classification) {
+            @Nullable Map<Term, Optional<String>> classification,
+            @Nullable Set<TaxonFlag> flags) {
         this.taxonID = taxonID;
         this.code = code;
         this.verbatimNomenclaturalCode = verbatimNomenclaturalCode;
@@ -251,6 +254,7 @@ public class TaxonConceptInstance extends TaxonomicElement<TaxonConceptInstance,
         this.verbatimTaxonRemarks = verbatimTaxonRemarks;
         this.provenance = provenance == null ? null : new ArrayList<>(provenance);
         this.classification = classification;
+        this.flags = flags;
     }
 
     /**
@@ -258,7 +262,7 @@ public class TaxonConceptInstance extends TaxonomicElement<TaxonConceptInstance,
      *
      * @return The nomenclatural code
      */
-    public NomenclaturalCode getCode() {
+    public NomenclaturalClassifier getCode() {
         return code;
     }
 
@@ -477,7 +481,7 @@ public class TaxonConceptInstance extends TaxonomicElement<TaxonConceptInstance,
      *
      * @return The nomenclatural code, as supplied
      */
-    public String getVerbatimNomenclaturalCode() {
+    public String getVerbatimNomenclaturalClassifier() {
         return verbatimNomenclaturalCode;
     }
 
@@ -643,6 +647,15 @@ public class TaxonConceptInstance extends TaxonomicElement<TaxonConceptInstance,
      */
     public boolean isForbidden() {
         return forbidden;
+    }
+
+    /**
+     * Get the flags associated with the taxon
+     *
+     * @return The taxon flags (null for none)
+     */
+    public Set<TaxonFlag> getFlags() {
+        return this.flags;
     }
 
     /**
@@ -1396,7 +1409,8 @@ public class TaxonConceptInstance extends TaxonomicElement<TaxonConceptInstance,
                 this.taxonRemarks == null ? null : new ArrayList<>(this.taxonRemarks),
                 this.verbatimTaxonRemarks,
                 this.provenance == null ? null : new ArrayList<>(this.provenance),
-                this.classification
+                this.classification,
+                this.flags
         );
         synonym.setContainer(concept);
         synonym.accepted = this;
@@ -1442,7 +1456,8 @@ public class TaxonConceptInstance extends TaxonomicElement<TaxonConceptInstance,
                 this.taxonRemarks == null ? null : new ArrayList<>(this.taxonRemarks),
                 this.verbatimTaxonRemarks,
                 this.provenance == null ? null : new ArrayList<>(this.provenance),
-                this.classification
+                this.classification,
+                this.flags
         );
         instance.setContainer(null);
         instance.accepted = this.accepted;

--- a/ala-name-matching-builder/src/main/java/au/org/ala/names/index/provider/KeyAdjustment.java
+++ b/ala-name-matching-builder/src/main/java/au/org/ala/names/index/provider/KeyAdjustment.java
@@ -17,11 +17,11 @@
 package au.org.ala.names.index.provider;
 
 import au.org.ala.names.index.NameKey;
+import au.org.ala.names.index.NomenclaturalClassifier;
 import au.org.ala.names.index.TaxonConceptInstance;
 import au.org.ala.names.model.RankType;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.gbif.api.vocabulary.NameType;
-import org.gbif.api.vocabulary.NomenclaturalCode;
 
 import javax.annotation.Nullable;
 
@@ -48,7 +48,7 @@ public class KeyAdjustment {
     private TaxonCondition condition;
     /** The replacement nomenclaturalCode */
     @JsonProperty
-    private NomenclaturalCode nomenclaturalCode;
+    private NomenclaturalClassifier nomenclaturalCode;
     /** The replacement scientific name */
     @JsonProperty
     private String scientificName;
@@ -78,7 +78,7 @@ public class KeyAdjustment {
      * @param nameType The new name type, or null for do not replace
      * @param rank The new rank, or null for do not replace
      */
-    public KeyAdjustment(TaxonCondition condition, @Nullable NomenclaturalCode nomenclaturalCode, @Nullable String scientificName, @Nullable String scientificNameAuthorship, @Nullable NameType nameType, @Nullable RankType rank) {
+    public KeyAdjustment(TaxonCondition condition, @Nullable NomenclaturalClassifier nomenclaturalCode, @Nullable String scientificName, @Nullable String scientificNameAuthorship, @Nullable NameType nameType, @Nullable RankType rank) {
         this.condition = condition;
         this.nomenclaturalCode = nomenclaturalCode;
         this.scientificName = scientificName;
@@ -90,7 +90,7 @@ public class KeyAdjustment {
     public NameKey adjust(NameKey key, TaxonConceptInstance instance) {
         if (!this.condition.match(instance, key))
             return key;
-        NomenclaturalCode nc = this.nomenclaturalCode != null ? this.nomenclaturalCode : key.getCode();
+        NomenclaturalClassifier nc = this.nomenclaturalCode != null ? this.nomenclaturalCode : key.getCode();
         String sn = this.scientificName != null ? this.scientificName : key.getScientificName();
         String sna = this.scientificNameAuthorship  != null ? this.scientificNameAuthorship : key.getScientificNameAuthorship();
         if (sna != null && sna.isEmpty())

--- a/ala-name-matching-builder/src/main/java/au/org/ala/names/index/provider/MatchTaxonCondition.java
+++ b/ala-name-matching-builder/src/main/java/au/org/ala/names/index/provider/MatchTaxonCondition.java
@@ -17,12 +17,13 @@
 package au.org.ala.names.index.provider;
 
 import au.org.ala.names.index.NameKey;
+import au.org.ala.names.index.NomenclaturalClassifier;
 import au.org.ala.names.index.TaxonConceptInstance;
 import au.org.ala.names.model.RankType;
+import au.org.ala.names.model.TaxonFlag;
 import au.org.ala.names.model.TaxonomicType;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.gbif.api.vocabulary.NameType;
-import org.gbif.api.vocabulary.NomenclaturalCode;
 import org.gbif.api.vocabulary.NomenclaturalStatus;
 import org.gbif.checklistbank.authorship.AuthorComparator;
 import org.gbif.checklistbank.model.Equality;
@@ -44,7 +45,7 @@ public class MatchTaxonCondition extends TaxonCondition {
     private static AuthorComparator AUTHOR_COMPARATOR = AuthorComparator.createWithAuthormap();
 
     /** Compare nomenclatural code */
-    private NomenclaturalCode nomenclaturalCode;
+    private NomenclaturalClassifier nomenclaturalCode;
     /** Source dataset */
     private String datasetID;
     /** Compare scientific name */
@@ -75,6 +76,8 @@ public class MatchTaxonCondition extends TaxonCondition {
     private RankType taxonRank;
     /** Compare year */
     private String year;
+    /** Test flag */
+    private TaxonFlag taxonomicFlag;
 
     /**
      * Default, empty constructor
@@ -82,11 +85,11 @@ public class MatchTaxonCondition extends TaxonCondition {
     public MatchTaxonCondition() {
     }
 
-    public NomenclaturalCode getNomenclaturalCode() {
+    public NomenclaturalClassifier getNomenclaturalCode() {
         return nomenclaturalCode;
     }
 
-    public void setNomenclaturalCode(NomenclaturalCode nomenclaturalCode) {
+    public void setNomenclaturalCode(NomenclaturalClassifier nomenclaturalCode) {
         this.nomenclaturalCode = nomenclaturalCode;
     }
 
@@ -170,6 +173,14 @@ public class MatchTaxonCondition extends TaxonCondition {
         this.year = year;
     }
 
+    public TaxonFlag getTaxonomicFlag() {
+        return taxonomicFlag;
+    }
+
+    public void setTaxonomicFlag(TaxonFlag taxonomicFlag) {
+        this.taxonomicFlag = taxonomicFlag;
+    }
+
     /**
      * Match the taxon instance against the supplied conditions.
      *
@@ -195,7 +206,11 @@ public class MatchTaxonCondition extends TaxonCondition {
             return false;
         if (this.taxonRank != null && this.taxonRank != instance.getRank())
             return false;
-        return this.year == null || this.year.equals(instance.getYear());
+        if (this.year != null && !this.year.equals(instance.getYear()))
+            return false;
+        if (this.taxonomicFlag != null && (instance.getFlags() == null || !instance.getFlags().contains(this.taxonomicFlag)))
+            return false;
+        return true;
     }
 
     /**
@@ -290,6 +305,8 @@ public class MatchTaxonCondition extends TaxonCondition {
         this.explain(builder, "nomenclaturalStatus", this.nomenclaturalStatus);
         this.explain(builder, "nameType", this.nameType);
         this.explain(builder, "taxonRank", this.taxonRank);
+        this.explain(builder, "year", this.year);
+        this.explain(builder, "taxonomicFlag", this.taxonomicFlag);
         return builder.toString();
     }
 

--- a/ala-name-matching-builder/src/main/resources/au/org/ala/names/index/nomenclatural_classifiers.csv
+++ b/ala-name-matching-builder/src/main/resources/au/org/ala/names/index/nomenclatural_classifiers.csv
@@ -1,0 +1,10 @@
+acronym,parent,title,source,code,aliases
+EUK,,Generic Eukaryota,,
+ICNB,,International Code of Nomenclature of Bacteria,http://www.ncbi.nlm.nih.gov/books/NBK8808/,BACTERIAL,NCGN
+ICBN,EUK,International Code of Botanical Nomenclature,http://ibot.sav.sk/icbn/main.htm,BOTANICAL,ICN,ICNAFP
+BC,,BioCode,http://www.bgbm.org/iapt/biocode/,BIOCODE
+ICNCP,ICBN,International Code of Nomenclature for Cultivated Plants,,CULTIVARS
+PC,,Phylocode,http://www.ohio.edu/phylocode/index.html,PHYLOCODE
+ICPN,,International Code of Phytosociological Nomenclature,http://www.iavs.org/pdf/Code.pdf,PHYTOSOCIOLOGY
+ICVCN,,International Code of Virus Classifications and Nomenclature,http://talk.ICTVonline.org/,VIRUS,ICVN
+ICZN,EUK,International Code of Zoological Nomenclature,http://www.nhm.ac.uk/hosted-sites/iczn/code/index.jsp,ZOOLOGICAL

--- a/ala-name-matching-builder/src/main/resources/au/org/ala/names/index/nomenclatural_codes.csv
+++ b/ala-name-matching-builder/src/main/resources/au/org/ala/names/index/nomenclatural_codes.csv
@@ -1,5 +1,0 @@
-acronym,NomenclaturalCode,title,link
-ICN,BOTANICAL,International Code of Nomenclature for algae, fungi, and plants,http://www.iapt-taxon.org/nomen/main.php
-ICNAFP,BOTANICAL,International Code of Nomenclature for algae, fungi, and plants,http://www.iapt-taxon.org/nomen/main.php
-ICVN,VIRUS,Variant of ICVCN,https://talk.ictvonline.org/
-NCGN,BACTERIAL,Incorrect code for Prokaryota,

--- a/ala-name-matching-builder/src/test/java/au/org/ala/names/index/ALANameAnalyserTest.java
+++ b/ala-name-matching-builder/src/test/java/au/org/ala/names/index/ALANameAnalyserTest.java
@@ -18,13 +18,18 @@
 
 package au.org.ala.names.index;
 
+import au.org.ala.names.index.provider.KeyAdjustment;
+import au.org.ala.names.index.provider.MatchTaxonCondition;
 import au.org.ala.names.model.RankType;
+import au.org.ala.names.model.TaxonFlag;
 import au.org.ala.names.model.TaxonomicType;
 import org.gbif.api.vocabulary.NameType;
-import org.gbif.api.vocabulary.NomenclaturalCode;
 import org.gbif.api.vocabulary.NomenclaturalStatus;
 import org.junit.Before;
 import org.junit.Test;
+
+import java.util.Collections;
+import java.util.Set;
 
 import static org.junit.Assert.*;
 
@@ -42,7 +47,7 @@ public class ALANameAnalyserTest {
     @Test
     public void testKey1() throws Exception {
         NameKey key = this.analyser.analyse("ICNAFP", "Hemigenia brachyphylla", "F.Muell.", "species");
-        assertEquals(NomenclaturalCode.BOTANICAL, key.getCode());
+        assertEquals(NomenclaturalClassifier.BOTANICAL, key.getCode());
         assertEquals(NameType.SCIENTIFIC, key.getType());
         assertEquals("HEMIGENIA BRACHIPHILA", key.getScientificName());
         assertEquals("F.Muell.", key.getScientificNameAuthorship());
@@ -51,7 +56,7 @@ public class ALANameAnalyserTest {
     @Test
     public void testKey2() throws Exception {
         NameKey key = this.analyser.analyse("ICZN", "Abantiades ocellatus", "Tindale, 1932", "species");
-        assertEquals(NomenclaturalCode.ZOOLOGICAL, key.getCode());
+        assertEquals(NomenclaturalClassifier.ZOOLOGICAL, key.getCode());
         assertEquals(NameType.SCIENTIFIC, key.getType());
         assertEquals("ABANTIADES OCELATA", key.getScientificName());
         assertEquals("Tindale, 1932", key.getScientificNameAuthorship());
@@ -60,7 +65,7 @@ public class ALANameAnalyserTest {
     @Test
     public void testKey3() throws Exception {
         NameKey key = this.analyser.analyse("ICZN", "Abantiades ocellatus", "Tindale, 1932", "species");
-        assertEquals(NomenclaturalCode.ZOOLOGICAL, key.getCode());
+        assertEquals(NomenclaturalClassifier.ZOOLOGICAL, key.getCode());
         assertEquals(NameType.SCIENTIFIC, key.getType());
         assertEquals("ABANTIADES OCELATA", key.getScientificName());
         assertEquals("Tindale, 1932", key.getScientificNameAuthorship());
@@ -77,7 +82,7 @@ public class ALANameAnalyserTest {
     @Test
     public void testKey5() throws Exception {
         NameKey key = this.analyser.analyse("ICNAFP", "Convolvulus sect. Brewera", null, "genus");
-        assertEquals(NomenclaturalCode.BOTANICAL, key.getCode());
+        assertEquals(NomenclaturalClassifier.BOTANICAL, key.getCode());
         assertEquals(NameType.SCIENTIFIC, key.getType());
         assertEquals("CONVOLVULUS BREWERA", key.getScientificName());
     }
@@ -85,7 +90,7 @@ public class ALANameAnalyserTest {
     @Test
     public void testKey6() throws Exception {
         NameKey key = this.analyser.analyse("ICNAFP", "Convolvulus sect. Brewera", null, "genus");
-        assertEquals(NomenclaturalCode.BOTANICAL, key.getCode());
+        assertEquals(NomenclaturalClassifier.BOTANICAL, key.getCode());
         assertEquals(NameType.SCIENTIFIC, key.getType());
         assertEquals("CONVOLVULUS BREWERA", key.getScientificName());
     }
@@ -94,21 +99,21 @@ public class ALANameAnalyserTest {
     @Test
     public void testKey7() throws Exception {
         NameKey key = this.analyser.analyse("ICZN", "Incertae sedis", null, "species");
-        assertEquals(NomenclaturalCode.ZOOLOGICAL, key.getCode());
+        assertEquals(NomenclaturalClassifier.ZOOLOGICAL, key.getCode());
         assertEquals(NameType.PLACEHOLDER, key.getType());
     }
 
     @Test
     public void testKey8() throws Exception {
         NameKey key = this.analyser.analyse("ICZN", "Unplaced acacia", null, "species");
-        assertEquals(NomenclaturalCode.ZOOLOGICAL, key.getCode());
+        assertEquals(NomenclaturalClassifier.ZOOLOGICAL, key.getCode());
         assertEquals(NameType.PLACEHOLDER, key.getType());
     }
 
     @Test
     public void testKey9() throws Exception {
         NameKey key = this.analyser.analyse("ICBN", "Entoloma sp. (C)", null, "species");
-        assertEquals(NomenclaturalCode.BOTANICAL, key.getCode());
+        assertEquals(NomenclaturalClassifier.BOTANICAL, key.getCode());
         assertEquals(NameType.INFORMAL, key.getType());
         assertEquals("ENTOLOMA C", key.getScientificName());
     }
@@ -116,7 +121,7 @@ public class ALANameAnalyserTest {
     @Test
     public void testKey10() throws Exception {
         NameKey key = this.analyser.analyse("ICNAFP", "Atriplex ser. Stipitata", null, "series botany");
-        assertEquals(NomenclaturalCode.BOTANICAL, key.getCode());
+        assertEquals(NomenclaturalClassifier.BOTANICAL, key.getCode());
         assertEquals(NameType.SCIENTIFIC, key.getType());
         assertEquals("ATRIPLEX STIPITATA", key.getScientificName());
     }
@@ -124,7 +129,7 @@ public class ALANameAnalyserTest {
     @Test
     public void testKey11() throws Exception {
         NameKey key = this.analyser.analyse("ICNAFP", "Atriplex stipitatum", null, "species");
-        assertEquals(NomenclaturalCode.BOTANICAL, key.getCode());
+        assertEquals(NomenclaturalClassifier.BOTANICAL, key.getCode());
         assertEquals(NameType.SCIENTIFIC, key.getType());
         assertEquals("ATRIPLEX STIPITATA", key.getScientificName());
     }
@@ -132,7 +137,7 @@ public class ALANameAnalyserTest {
     @Test
     public void testKey12() throws Exception {
         NameKey key = this.analyser.analyse("ICNAFP", "Brachyscome 'Pilliga Posy'", null, "species");
-        assertEquals(NomenclaturalCode.BOTANICAL, key.getCode());
+        assertEquals(NomenclaturalClassifier.BOTANICAL, key.getCode());
         assertEquals(NameType.CULTIVAR, key.getType());
         assertEquals("BRACHYSCOME 'PILLIGA POSY'", key.getScientificName());
         assertNull(key.getScientificNameAuthorship());
@@ -141,7 +146,7 @@ public class ALANameAnalyserTest {
     @Test
     public void testKey13() throws Exception {
         NameKey key = this.analyser.analyse("ICNAFP", "Eucalyptus caesia 'Silver Princess'", null, "species");
-        assertEquals(NomenclaturalCode.BOTANICAL, key.getCode());
+        assertEquals(NomenclaturalClassifier.BOTANICAL, key.getCode());
         assertEquals(NameType.CULTIVAR, key.getType());
         assertEquals("EUCALYPTUS CAESIA 'SILVER PRINCESS'", key.getScientificName());
         assertNull(key.getScientificNameAuthorship());
@@ -150,7 +155,7 @@ public class ALANameAnalyserTest {
     @Test
     public void testKey14() throws Exception {
         NameKey key = this.analyser.analyse("ICNAFP", "Munida aff. amathea", null, "species");
-        assertEquals(NomenclaturalCode.BOTANICAL, key.getCode());
+        assertEquals(NomenclaturalClassifier.BOTANICAL, key.getCode());
         assertEquals(NameType.DOUBTFUL, key.getType());
         assertEquals("MUNIDA AFF AMATHEA", key.getScientificName());
         assertNull(key.getScientificNameAuthorship());
@@ -159,7 +164,7 @@ public class ALANameAnalyserTest {
     @Test
     public void testKey15() throws Exception {
         NameKey key = this.analyser.analyse("ICNAFP", "Munida aff amathea", null, "species");
-        assertEquals(NomenclaturalCode.BOTANICAL, key.getCode());
+        assertEquals(NomenclaturalClassifier.BOTANICAL, key.getCode());
         assertEquals(NameType.DOUBTFUL, key.getType());
         assertEquals("MUNIDA AFF AMATHEA", key.getScientificName());
         assertNull(key.getScientificNameAuthorship());
@@ -168,7 +173,7 @@ public class ALANameAnalyserTest {
     @Test
     public void testKey16() throws Exception {
         NameKey key = this.analyser.analyse("ICNAFP", "Waminoa cf. brickneri", null, "species");
-        assertEquals(NomenclaturalCode.BOTANICAL, key.getCode());
+        assertEquals(NomenclaturalClassifier.BOTANICAL, key.getCode());
         assertEquals(NameType.DOUBTFUL, key.getType());
         assertEquals("WAMINOA CF BRICKNERI", key.getScientificName());
         assertNull(key.getScientificNameAuthorship());
@@ -176,8 +181,8 @@ public class ALANameAnalyserTest {
 
     @Test
     public void testKey17() throws Exception {
-        NameKey key = this.analyser.analyse(NomenclaturalCode.BOTANICAL, "Waminoa cf. brickneri", null, null, null, true);
-        assertEquals(NomenclaturalCode.BOTANICAL, key.getCode());
+        NameKey key = this.analyser.analyse(NomenclaturalClassifier.BOTANICAL, "Waminoa cf. brickneri", null, null, null, null, true);
+        assertEquals(NomenclaturalClassifier.BOTANICAL, key.getCode());
         assertEquals(NameType.DOUBTFUL, key.getType());
         assertEquals("WAMINOA CF BRICKNERI", key.getScientificName());
         assertNull(key.getScientificNameAuthorship());
@@ -186,8 +191,8 @@ public class ALANameAnalyserTest {
     // Autonym test
     @Test
     public void testKey18() throws Exception {
-        NameKey key = this.analyser.analyse(NomenclaturalCode.BOTANICAL, "Gonocarpus micranthus Thunb. subsp. micranthus", null, null, null, false);
-        assertEquals(NomenclaturalCode.BOTANICAL, key.getCode());
+        NameKey key = this.analyser.analyse(NomenclaturalClassifier.BOTANICAL, "Gonocarpus micranthus Thunb. subsp. micranthus", null, null, null, null, false);
+        assertEquals(NomenclaturalClassifier.BOTANICAL, key.getCode());
         assertEquals(NameType.SCIENTIFIC, key.getType());
         assertEquals("GONOCARPUS MICRANTHUS MICRANTHUS", key.getScientificName());
         assertNull(key.getScientificNameAuthorship());
@@ -196,8 +201,8 @@ public class ALANameAnalyserTest {
 
     @Test
     public void testKey19() throws Exception {
-        NameKey key = this.analyser.analyse(NomenclaturalCode.BOTANICAL, "Gonocarpus micranthus subsp. ramosissimus", "Orchard", null, null, false);
-        assertEquals(NomenclaturalCode.BOTANICAL, key.getCode());
+        NameKey key = this.analyser.analyse(NomenclaturalClassifier.BOTANICAL, "Gonocarpus micranthus subsp. ramosissimus", "Orchard", null, null, null, false);
+        assertEquals(NomenclaturalClassifier.BOTANICAL, key.getCode());
         assertEquals(NameType.SCIENTIFIC, key.getType());
         assertEquals("GONOCARPUS MICRANTUS RAMOSISIMA", key.getScientificName());
         assertEquals("Orchard", key.getScientificNameAuthorship());
@@ -206,8 +211,8 @@ public class ALANameAnalyserTest {
 
     @Test
     public void testKey20() throws Exception {
-        NameKey key = this.analyser.analyse(NomenclaturalCode.BOTANICAL, "Gonocarpus micranthus subsp. ramosissimus Orchard", null, null, null, true);
-        assertEquals(NomenclaturalCode.BOTANICAL, key.getCode());
+        NameKey key = this.analyser.analyse(NomenclaturalClassifier.BOTANICAL, "Gonocarpus micranthus subsp. ramosissimus Orchard", null, null, null, null, true);
+        assertEquals(NomenclaturalClassifier.BOTANICAL, key.getCode());
         assertEquals(NameType.SCIENTIFIC, key.getType());
         assertEquals("GONOCARPUS MICRANTUS RAMOSISIMA", key.getScientificName());
         assertEquals("Orchard", key.getScientificNameAuthorship());
@@ -216,8 +221,8 @@ public class ALANameAnalyserTest {
 
     @Test
     public void testKey21() throws Exception {
-        NameKey key = this.analyser.analyse(NomenclaturalCode.BOTANICAL, "Gonocarpus micranthus Thunb. subsp. micranthus", "Thunb.", null, null, false);
-        assertEquals(NomenclaturalCode.BOTANICAL, key.getCode());
+        NameKey key = this.analyser.analyse(NomenclaturalClassifier.BOTANICAL, "Gonocarpus micranthus Thunb. subsp. micranthus", "Thunb.", null, null, null, false);
+        assertEquals(NomenclaturalClassifier.BOTANICAL, key.getCode());
         assertEquals(NameType.SCIENTIFIC, key.getType());
         assertEquals("GONOCARPUS MICRANTHUS MICRANTHUS", key.getScientificName());
         assertNull(key.getScientificNameAuthorship());
@@ -227,8 +232,8 @@ public class ALANameAnalyserTest {
     // Author without trailing year marker
     @Test
     public void testKey22() throws Exception {
-        NameKey key = this.analyser.analyse(NomenclaturalCode.BACTERIAL, "Gemmatimonas aurantiaca Zhang et al. amerlia ", "Zhang et al.", null, null, false);
-        assertEquals(NomenclaturalCode.BACTERIAL, key.getCode());
+        NameKey key = this.analyser.analyse(NomenclaturalClassifier.BACTERIAL, "Gemmatimonas aurantiaca Zhang et al. amerlia ", "Zhang et al.", null, null, null, false);
+        assertEquals(NomenclaturalClassifier.BACTERIAL, key.getCode());
         assertEquals(NameType.SCIENTIFIC, key.getType());
         assertEquals("GEMMATIMONAS AURANTIACA AMERLIA", key.getScientificName());
         assertEquals("Zhang et al.", key.getScientificNameAuthorship());
@@ -238,8 +243,8 @@ public class ALANameAnalyserTest {
     // Author with trailing year marker
     @Test
     public void testKey23() throws Exception {
-        NameKey key = this.analyser.analyse(NomenclaturalCode.BACTERIAL, "Gemmatimonas aurantiaca Zhang et al., 1995", "Zhang et al.", null, null, false);
-        assertEquals(NomenclaturalCode.BACTERIAL, key.getCode());
+        NameKey key = this.analyser.analyse(NomenclaturalClassifier.BACTERIAL, "Gemmatimonas aurantiaca Zhang et al., 1995", "Zhang et al.", null, null, null, false);
+        assertEquals(NomenclaturalClassifier.BACTERIAL, key.getCode());
         assertEquals(NameType.SCIENTIFIC, key.getType());
         assertEquals("GEMMATIMONAS AURANTIACA", key.getScientificName());
         assertEquals("Zhang et al.", key.getScientificNameAuthorship());
@@ -249,8 +254,8 @@ public class ALANameAnalyserTest {
     // Author with trailing year marker
     @Test
     public void testKey24() throws Exception {
-        NameKey key = this.analyser.analyse(NomenclaturalCode.BACTERIAL, "Gemmatimonas aurantiaca Zhang et al., 1995 amerlia", "Zhang et al.", null, null, false);
-        assertEquals(NomenclaturalCode.BACTERIAL, key.getCode());
+        NameKey key = this.analyser.analyse(NomenclaturalClassifier.BACTERIAL, "Gemmatimonas aurantiaca Zhang et al., 1995 amerlia", "Zhang et al.", null, null, null, false);
+        assertEquals(NomenclaturalClassifier.BACTERIAL, key.getCode());
         assertEquals(NameType.SCIENTIFIC, key.getType());
         assertEquals("GEMMATIMONAS AURANTIACA AMERLIA", key.getScientificName());
         assertEquals("Zhang et al.", key.getScientificNameAuthorship());
@@ -261,8 +266,8 @@ public class ALANameAnalyserTest {
     // Test quoted genus
     @Test
     public void testKey25() throws Exception {
-        NameKey key = this.analyser.analyse(NomenclaturalCode.ZOOLOGICAL, "\"Hypomecis\" catephes", "(Turner, 1947)", null, null, false);
-        assertEquals(NomenclaturalCode.ZOOLOGICAL, key.getCode());
+        NameKey key = this.analyser.analyse(NomenclaturalClassifier.ZOOLOGICAL, "\"Hypomecis\" catephes", "(Turner, 1947)", null, null, null, false);
+        assertEquals(NomenclaturalClassifier.ZOOLOGICAL, key.getCode());
         assertEquals(NameType.DOUBTFUL, key.getType());
         assertEquals("\"HYPOMECIS\" CATEPHES", key.getScientificName());
         assertEquals("(Turner, 1947)", key.getScientificNameAuthorship());
@@ -274,7 +279,7 @@ public class ALANameAnalyserTest {
     @Test
     public void testKey26() throws Exception {
         // With authot
-        NameKey key1 = this.analyser.analyse(null, "Carex aff. tereticaulis (Lake Omeo)", "sensu G.W. Carr", RankType.UNRANKED, TaxonomicType.INFERRED_UNPLACED, true);
+        NameKey key1 = this.analyser.analyse(null, "Carex aff. tereticaulis (Lake Omeo)", "sensu G.W. Carr", RankType.UNRANKED, TaxonomicType.INFERRED_UNPLACED, null, true);
         assertEquals(null, key1.getCode());
         assertEquals(NameType.DOUBTFUL, key1.getType());
         assertEquals("CAREX AFF TERETICAULIS LAKE OMEO", key1.getScientificName());
@@ -282,12 +287,40 @@ public class ALANameAnalyserTest {
         assertEquals(RankType.UNRANKED, key1.getRank());
 
         // Without author
-        NameKey key2 = this.analyser.analyse(null, "Carex aff. tereticaulis (Lake Omeo)", null, RankType.UNRANKED, TaxonomicType.INFERRED_UNPLACED, true);
+        NameKey key2 = this.analyser.analyse(null, "Carex aff. tereticaulis (Lake Omeo)", null, RankType.UNRANKED, TaxonomicType.INFERRED_UNPLACED, null, true);
         assertEquals(null, key2.getCode());
         assertEquals(NameType.DOUBTFUL, key2.getType());
         assertEquals("CAREX AFF TERETICAULIS LAKE OMEO", key2.getScientificName());
         assertEquals(null, key2.getScientificNameAuthorship());
         assertEquals(RankType.UNRANKED, key2.getRank());
+    }
+
+    // Test flags
+    @Test
+    public void testKey27() throws Exception {
+        Set<TaxonFlag> flags = Collections.singleton(TaxonFlag.AMBIGUOUS_NOMENCLATURAL_CODE);
+        NameKey key1 = this.analyser.analyse(NomenclaturalClassifier.BOTANICAL, "Aulacoseira ambigua", "(Grunov) Simonsen", RankType.SPECIES, TaxonomicType.INFERRED_ACCEPTED, flags, true);
+        assertEquals(NomenclaturalClassifier.BOTANICAL, key1.getCode());
+        assertEquals(NameType.SCIENTIFIC, key1.getType());
+        assertEquals("AULACOSEIRA AMBIGUA", key1.getScientificName());
+        assertEquals("(Grunov) Simonsen", key1.getScientificNameAuthorship());
+        assertEquals(RankType.SPECIES, key1.getRank());
+        assertSame(flags, key1.getFlags());
+    }
+
+    // Test flags
+    @Test
+    public void testKey28() throws Exception {
+        Set<TaxonFlag> flags = Collections.singleton(TaxonFlag.AMBIGUOUS_NOMENCLATURAL_CODE);
+        NameKey key1 = this.analyser.analyse(NomenclaturalClassifier.BOTANICAL, "Aulacoseira ambigua ambigua", "(Grunov) Simonsen", RankType.SPECIES, TaxonomicType.INFERRED_ACCEPTED, flags, true);
+        assertEquals(NomenclaturalClassifier.BOTANICAL, key1.getCode());
+        assertEquals(NameType.SCIENTIFIC, key1.getType());
+        assertEquals("AULACOSEIRA AMBIGUA AMBIGUA", key1.getScientificName());
+        assertNull(key1.getScientificNameAuthorship());
+        assertEquals(RankType.SPECIES, key1.getRank());
+        assertNotSame(flags, key1.getFlags());
+        assertTrue(key1.getFlags().contains(TaxonFlag.AUTONYM));
+        assertTrue(key1.getFlags().contains(TaxonFlag.AMBIGUOUS_NOMENCLATURAL_CODE));
     }
 
     @Test
@@ -320,8 +353,8 @@ public class ALANameAnalyserTest {
 
     @Test
     public void testKeyEquals1() throws Exception {
-        NameKey key1 = this.analyser.analyse(NomenclaturalCode.BOTANICAL, "Hemigenia brachyphylla F.Muell.", null, RankType.SPECIES, null, true);
-        NameKey key2 = this.analyser.analyse(NomenclaturalCode.BOTANICAL, "Hemigenia brachyphylla F.Mueller", null, RankType.SPECIES, null, true);
+        NameKey key1 = this.analyser.analyse(NomenclaturalClassifier.BOTANICAL, "Hemigenia brachyphylla F.Muell.", null, RankType.SPECIES, null, null, true);
+        NameKey key2 = this.analyser.analyse(NomenclaturalClassifier.BOTANICAL, "Hemigenia brachyphylla F.Mueller", null, RankType.SPECIES, null, null, true);
         assertTrue(key1.equals(key2));
     }
 
@@ -391,8 +424,8 @@ public class ALANameAnalyserTest {
     // Loose names
     @Test
     public void testkeyEquals11() throws Exception {
-        NameKey key1 = this.analyser.analyse(null, "Acaena rorida", "B.H.Macmill.", null, null, false);
-        NameKey key2 = this.analyser.analyse(null, "Acaena rorida B.H.Macmill.", null, null, null, true);
+        NameKey key1 = this.analyser.analyse(null, "Acaena rorida", "B.H.Macmill.", null, null, null, false);
+        NameKey key2 = this.analyser.analyse(null, "Acaena rorida B.H.Macmill.", null, null, null, null, true);
         assertTrue(key1.equals(key2));
     }
 
@@ -436,23 +469,23 @@ public class ALANameAnalyserTest {
     // Placeholder names
     @Test
     public void testKeyEquals17() throws Exception {
-        NameKey key1 = this.analyser.analyse(NomenclaturalCode.BOTANICAL, "Incertae sedis", "F.Muell.", RankType.SPECIES, TaxonomicType.ACCEPTED, false);
-        NameKey key2 = this.analyser.analyse(NomenclaturalCode.BOTANICAL, "Incertae sedis", "F.Muell.", RankType.SPECIES, TaxonomicType.ACCEPTED, false);
+        NameKey key1 = this.analyser.analyse(NomenclaturalClassifier.BOTANICAL, "Incertae sedis", "F.Muell.", RankType.SPECIES, TaxonomicType.ACCEPTED, null, false);
+        NameKey key2 = this.analyser.analyse(NomenclaturalClassifier.BOTANICAL, "Incertae sedis", "F.Muell.", RankType.SPECIES, TaxonomicType.ACCEPTED, null, false);
         assertFalse(key1.equals(key2));
     }
 
     @Test
     public void testKeyEquals18() throws Exception {
-        NameKey key1 = this.analyser.analyse(NomenclaturalCode.BOTANICAL, "Hemigenia brachyphylla", "F.Muell.", RankType.SPECIES, TaxonomicType.INCERTAE_SEDIS, false);
-        NameKey key2 = this.analyser.analyse(NomenclaturalCode.BOTANICAL, "Hemigenia brachyphylla", "F.Muell.", RankType.SPECIES, TaxonomicType.INCERTAE_SEDIS, false);
+        NameKey key1 = this.analyser.analyse(NomenclaturalClassifier.BOTANICAL, "Hemigenia brachyphylla", "F.Muell.", RankType.SPECIES, TaxonomicType.INCERTAE_SEDIS, null, false);
+        NameKey key2 = this.analyser.analyse(NomenclaturalClassifier.BOTANICAL, "Hemigenia brachyphylla", "F.Muell.", RankType.SPECIES, TaxonomicType.INCERTAE_SEDIS, null, false);
         assertFalse(key1.equals(key2));
     }
 
     // Autonyms
     @Test
     public void testKeyEquals19() throws Exception {
-        NameKey key1 = this.analyser.analyse(NomenclaturalCode.BOTANICAL, "Senecio glomeratus Desf. ex Poir. subsp. glomeratus", null, null, null, false);
-        NameKey key2 = this.analyser.analyse(NomenclaturalCode.BOTANICAL, "Senecio glomeratus Poir. subsp. glomeratus", "Poir.", null, null, false);
+        NameKey key1 = this.analyser.analyse(NomenclaturalClassifier.BOTANICAL, "Senecio glomeratus Desf. ex Poir. subsp. glomeratus", null, null, null, null, false);
+        NameKey key2 = this.analyser.analyse(NomenclaturalClassifier.BOTANICAL, "Senecio glomeratus Poir. subsp. glomeratus", "Poir.", null, null, null, false);
         assertTrue(key1.isAutonym());
         assertTrue(key2.isAutonym());
         assertEquals(key1, key2);
@@ -461,67 +494,66 @@ public class ALANameAnalyserTest {
     // Escaped letters
     @Test
     public void testKeyEquals20() throws Exception {
-        NameKey key1 = this.analyser.analyse(NomenclaturalCode.BOTANICAL, "Senecio \\glomeratus", "Poir.", null, null, false);
-        NameKey key2 = this.analyser.analyse(NomenclaturalCode.BOTANICAL, "Senecio glomeratus", "Poir.", null, null, false);
+        NameKey key1 = this.analyser.analyse(NomenclaturalClassifier.BOTANICAL, "Senecio \\glomeratus", "Poir.", null, null, null, false);
+        NameKey key2 = this.analyser.analyse(NomenclaturalClassifier.BOTANICAL, "Senecio glomeratus", "Poir.", null, null, null, false);
         assertEquals(key1, key2);
     }
 
     @Test
     public void testKeyEquals21() throws Exception {
-        NameKey key1 = this.analyser.analyse(NomenclaturalCode.BOTANICAL, "Senecio glomeratus", "\\(Poir\\.\\)", null, null, false);
-        NameKey key2 = this.analyser.analyse(NomenclaturalCode.BOTANICAL, "Senecio glomeratus", "(Poir.)", null, null, false);
+        NameKey key1 = this.analyser.analyse(NomenclaturalClassifier.BOTANICAL, "Senecio glomeratus", "\\(Poir\\.\\)", null, null, null, false);
+        NameKey key2 = this.analyser.analyse(NomenclaturalClassifier.BOTANICAL, "Senecio glomeratus", "(Poir.)", null, null, null, false);
         assertEquals(key1, key2);
     }
 
     // Ampersands
     @Test
     public void testKeyEquals22() throws Exception {
-        NameKey key1 = this.analyser.analyse(NomenclaturalCode.BOTANICAL, "Senecio glomeratus", "Poir.  and Labil", null, null, false);
-        NameKey key2 = this.analyser.analyse(NomenclaturalCode.BOTANICAL, "Senecio glomeratus", "Poir. &  Labil", null, null, false);
+        NameKey key1 = this.analyser.analyse(NomenclaturalClassifier.BOTANICAL, "Senecio glomeratus", "Poir.  and Labil", null, null, null, false);
+        NameKey key2 = this.analyser.analyse(NomenclaturalClassifier.BOTANICAL, "Senecio glomeratus", "Poir. &  Labil", null, null, null, false);
         assertEquals(key1, key2);
     }
 
     // Changed combination marker
     @Test
     public void testKeyEquals23() throws Exception {
-        NameKey key1 = this.analyser.analyse(NomenclaturalCode.ZOOLOGICAL, "Osphranter rufus", "Desmarest, 1822", null, null, false);
-        NameKey key2 = this.analyser.analyse(NomenclaturalCode.ZOOLOGICAL, "Osphranter rufus", "(Desmarest, 1822)", null, null, false);
+        NameKey key1 = this.analyser.analyse(NomenclaturalClassifier.ZOOLOGICAL, "Osphranter rufus", "Desmarest, 1822", null, null, null, false);
+        NameKey key2 = this.analyser.analyse(NomenclaturalClassifier.ZOOLOGICAL, "Osphranter rufus", "(Desmarest, 1822)", null, null, null, false);
         assertEquals(key1, key2);
     }
 
     // Placeholder names
     @Test
     public void testKeyEquals24() throws Exception {
-        NameKey key1 = this.analyser.analyse(NomenclaturalCode.ZOOLOGICAL, "Galaxias sp. 3", null, null, null, false);
-        NameKey key2 = this.analyser.analyse(NomenclaturalCode.ZOOLOGICAL, "Galaxias sp 3", null, null, null, false);
+        NameKey key1 = this.analyser.analyse(NomenclaturalClassifier.ZOOLOGICAL, "Galaxias sp. 3", null, null, null, null, false);
+        NameKey key2 = this.analyser.analyse(NomenclaturalClassifier.ZOOLOGICAL, "Galaxias sp 3", null, null, null, null, false);
         assertEquals(key1, key2);
     }
 
     @Test
     public void testKeyEquals25() throws Exception {
-        NameKey key1 = this.analyser.analyse(NomenclaturalCode.ZOOLOGICAL, "Galaxias sp. 3", null, null, null, false);
-        NameKey key2 = this.analyser.analyse(NomenclaturalCode.ZOOLOGICAL, "Galaxias sp 3", null, null, null, true);
+        NameKey key1 = this.analyser.analyse(NomenclaturalClassifier.ZOOLOGICAL, "Galaxias sp. 3", null, null, null, null, false);
+        NameKey key2 = this.analyser.analyse(NomenclaturalClassifier.ZOOLOGICAL, "Galaxias sp 3", null, null, null, null, true);
         assertEquals(key1, key2);
     }
 
     // Initially quoted names
     @Test
     public void testKeyEquals26() throws Exception {
-        NameKey key1 = this.analyser.analyse(NomenclaturalCode.ZOOLOGICAL, "\"Hypomecis\" catephes", null, RankType.SPECIES, null, false);
-        NameKey key2 = this.analyser.analyse(NomenclaturalCode.ZOOLOGICAL, "Hypomecis catephes", null, RankType.SPECIES, null, false);
+        NameKey key1 = this.analyser.analyse(NomenclaturalClassifier.ZOOLOGICAL, "\"Hypomecis\" catephes", null, RankType.SPECIES, null, null, false);
+        NameKey key2 = this.analyser.analyse(NomenclaturalClassifier.ZOOLOGICAL, "Hypomecis catephes", null, RankType.SPECIES, null, null, false);
         assertNotEquals(key1, key2);
     }
 
-
     @Test
     public void testCanonicaliseCode1() throws Exception {
-        NomenclaturalCode code = this.analyser.canonicaliseCode("ICZN");
-        assertEquals(NomenclaturalCode.ZOOLOGICAL, code);
+        NomenclaturalClassifier code = this.analyser.canonicaliseCode("ICZN");
+        assertEquals(NomenclaturalClassifier.ZOOLOGICAL, code);
     }
 
     @Test
     public void testCanonicaliseCode2() throws Exception {
-        NomenclaturalCode code = this.analyser.canonicaliseCode("FLUFFY");
+        NomenclaturalClassifier code = this.analyser.canonicaliseCode("FLUFFY");
         assertNull(code);
     }
 

--- a/ala-name-matching-builder/src/test/java/au/org/ala/names/index/CSVNameSourceTest.java
+++ b/ala-name-matching-builder/src/test/java/au/org/ala/names/index/CSVNameSourceTest.java
@@ -19,7 +19,6 @@ package au.org.ala.names.index;
 import au.org.ala.names.model.RankType;
 import au.org.ala.names.model.TaxonomicType;
 import au.org.ala.names.util.TestUtils;
-import org.gbif.api.vocabulary.NomenclaturalCode;
 import org.gbif.dwc.terms.DwcTerm;
 import org.gbif.dwc.terms.Term;
 import org.junit.After;
@@ -80,7 +79,7 @@ public class CSVNameSourceTest extends TestUtils {
         assertNull(instance.getAcceptedNameUsageID());
         assertEquals("http://id.biodiversity.org.au/node/ausmoss/10044709", instance.getParentNameUsageID());
         assertEquals("http://id.biodiversity.org.au/node/ausmoss/10044710", instance.getTaxonID());
-        assertEquals(NomenclaturalCode.BOTANICAL, instance.getCode());
+        assertEquals(NomenclaturalClassifier.BOTANICAL, instance.getCode());
         assertNotNull(instance.getProvider());
         assertEquals("dr100", instance.getProvider().getId());
         assertEquals(RankType.SUBCLASS, instance.getRank());
@@ -110,7 +109,7 @@ public class CSVNameSourceTest extends TestUtils {
         assertNull(instance.getAcceptedNameUsageID());
         assertNull(instance.getParentNameUsageID());
         assertEquals("http://id.biodiversity.org.au/node/ausmoss/10044710", instance.getTaxonID());
-        assertEquals(NomenclaturalCode.BOTANICAL, instance.getCode());
+        assertEquals(NomenclaturalClassifier.BOTANICAL, instance.getCode());
         assertNotNull(instance.getProvider());
         assertEquals("default", instance.getProvider().getId());
         assertEquals(RankType.SUBCLASS, instance.getRank());

--- a/ala-name-matching-builder/src/test/java/au/org/ala/names/index/NameProviderTest.java
+++ b/ala-name-matching-builder/src/test/java/au/org/ala/names/index/NameProviderTest.java
@@ -19,7 +19,6 @@ package au.org.ala.names.index;
 import au.org.ala.names.model.TaxonomicType;
 import au.org.ala.names.util.TestUtils;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.gbif.api.vocabulary.NomenclaturalCode;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -80,9 +79,9 @@ public class NameProviderTest extends TestUtils {
     @Test
     public void testBaseScore1() {
         NameProvider provider = this.getProvider("ID-3");
-        TaxonConceptInstance instance1 = this.createInstance("ID-1", NomenclaturalCode.BOTANICAL, "Acacia dealbata", provider);
-        TaxonConceptInstance instance2 = this.createInstance("ID-1", NomenclaturalCode.BOTANICAL, "Acacia", provider);
-        TaxonConceptInstance instance3 = this.createInstance("ID-1", NomenclaturalCode.ZOOLOGICAL, "Macropus", provider);
+        TaxonConceptInstance instance1 = this.createInstance("ID-1", NomenclaturalClassifier.BOTANICAL, "Acacia dealbata", provider);
+        TaxonConceptInstance instance2 = this.createInstance("ID-1", NomenclaturalClassifier.BOTANICAL, "Acacia", provider);
+        TaxonConceptInstance instance3 = this.createInstance("ID-1", NomenclaturalClassifier.ZOOLOGICAL, "Macropus", provider);
         assertEquals(100, provider.computeBaseScore(instance1, instance1));
         assertEquals(150, provider.computeBaseScore(instance2, instance2));
         assertEquals(90, provider.computeBaseScore(instance3, instance3));
@@ -91,9 +90,9 @@ public class NameProviderTest extends TestUtils {
     @Test
     public void testBaseScore2() {
         NameProvider provider = this.getProvider("ID-4");
-        TaxonConceptInstance instance1 = this.createInstance("ID-1", NomenclaturalCode.BOTANICAL, "Acacia dealbata", provider);
-        TaxonConceptInstance instance2 = this.createInstance("ID-1", NomenclaturalCode.BOTANICAL, "Acacia", provider);
-        TaxonConceptInstance instance3 = this.createInstance("ID-1", NomenclaturalCode.ZOOLOGICAL, "Macropus", provider);
+        TaxonConceptInstance instance1 = this.createInstance("ID-1", NomenclaturalClassifier.BOTANICAL, "Acacia dealbata", provider);
+        TaxonConceptInstance instance2 = this.createInstance("ID-1", NomenclaturalClassifier.BOTANICAL, "Acacia", provider);
+        TaxonConceptInstance instance3 = this.createInstance("ID-1", NomenclaturalClassifier.ZOOLOGICAL, "Macropus", provider);
         assertEquals(100, provider.computeBaseScore(instance1, instance1));
         assertEquals(100, provider.computeBaseScore(instance2, instance2));
         assertEquals(90, provider.computeBaseScore(instance3, instance3));
@@ -102,10 +101,10 @@ public class NameProviderTest extends TestUtils {
     @Test
     public void testScore1() {
         NameProvider provider = this.getProvider("ID-5");
-        TaxonConceptInstance instance1 = this.createInstance("ID-1", NomenclaturalCode.BOTANICAL, "Acacia dealbata", provider);
-        TaxonConceptInstance instance2 = this.createInstance("ID-1", NomenclaturalCode.BOTANICAL, "Acacia", provider);
-        TaxonConceptInstance instance3 = this.createInstance("ID-1", NomenclaturalCode.ZOOLOGICAL, "Macropus", provider);
-        TaxonConceptInstance instance4 = this.createInstance("ID-1", NomenclaturalCode.ZOOLOGICAL, "Macropus", provider, TaxonomicType.EXCLUDED);
+        TaxonConceptInstance instance1 = this.createInstance("ID-1", NomenclaturalClassifier.BOTANICAL, "Acacia dealbata", provider);
+        TaxonConceptInstance instance2 = this.createInstance("ID-1", NomenclaturalClassifier.BOTANICAL, "Acacia", provider);
+        TaxonConceptInstance instance3 = this.createInstance("ID-1", NomenclaturalClassifier.ZOOLOGICAL, "Macropus", provider);
+        TaxonConceptInstance instance4 = this.createInstance("ID-1", NomenclaturalClassifier.ZOOLOGICAL, "Macropus", provider, TaxonomicType.EXCLUDED);
         assertEquals(110, provider.computeScore(instance1));
         assertEquals(160, provider.computeScore(instance2));
         assertEquals(90, provider.computeScore(instance3));
@@ -116,10 +115,10 @@ public class NameProviderTest extends TestUtils {
     @Test
     public void testScore2() {
         NameProvider provider = this.getProvider("ID-6");
-        TaxonConceptInstance instance1 = this.createInstance("ID-1", NomenclaturalCode.BOTANICAL, "Acacia dealbata", provider);
-        TaxonConceptInstance instance2 = this.createInstance("ID-1", NomenclaturalCode.BOTANICAL, "Acacia", provider);
-        TaxonConceptInstance instance3 = this.createInstance("ID-1", NomenclaturalCode.ZOOLOGICAL, "Macropus", provider, TaxonomicType.INFERRED_ACCEPTED);
-        TaxonConceptInstance instance4 = this.createInstance("ID-1", NomenclaturalCode.ZOOLOGICAL, "Macropus", provider, TaxonomicType.EXCLUDED);
+        TaxonConceptInstance instance1 = this.createInstance("ID-1", NomenclaturalClassifier.BOTANICAL, "Acacia dealbata", provider);
+        TaxonConceptInstance instance2 = this.createInstance("ID-1", NomenclaturalClassifier.BOTANICAL, "Acacia", provider);
+        TaxonConceptInstance instance3 = this.createInstance("ID-1", NomenclaturalClassifier.ZOOLOGICAL, "Macropus", provider, TaxonomicType.INFERRED_ACCEPTED);
+        TaxonConceptInstance instance4 = this.createInstance("ID-1", NomenclaturalClassifier.ZOOLOGICAL, "Macropus", provider, TaxonomicType.EXCLUDED);
         assertEquals(110, provider.computeScore(instance1));
         assertEquals(160, provider.computeScore(instance2));
         assertEquals(70, provider.computeScore(instance3));
@@ -129,13 +128,13 @@ public class NameProviderTest extends TestUtils {
     @Test
     public void testForbid1() {
         NameProvider provider = this.getProvider("ID-5");
-        TaxonConceptInstance instance1 = this.createInstance("ID-1", NomenclaturalCode.BOTANICAL, "Acacia dealbata", provider);
+        TaxonConceptInstance instance1 = this.createInstance("ID-1", NomenclaturalClassifier.BOTANICAL, "Acacia dealbata", provider);
         NameKey key1 = this.analyser.analyse(instance1);
-        TaxonConceptInstance instance2 = this.createInstance("ID-1", NomenclaturalCode.BOTANICAL, "Acacia", provider);
+        TaxonConceptInstance instance2 = this.createInstance("ID-1", NomenclaturalClassifier.BOTANICAL, "Acacia", provider);
         NameKey key2 = this.analyser.analyse(instance2);
-        TaxonConceptInstance instance3 = this.createInstance("ID-1", NomenclaturalCode.ZOOLOGICAL, "Macropus", provider);
+        TaxonConceptInstance instance3 = this.createInstance("ID-1", NomenclaturalClassifier.ZOOLOGICAL, "Macropus", provider);
         NameKey key3 = this.analyser.analyse(instance3);
-        TaxonConceptInstance instance4 = this.createInstance("ID-1", NomenclaturalCode.ZOOLOGICAL, "Macropus", provider, TaxonomicType.INCERTAE_SEDIS);
+        TaxonConceptInstance instance4 = this.createInstance("ID-1", NomenclaturalClassifier.ZOOLOGICAL, "Macropus", provider, TaxonomicType.INCERTAE_SEDIS);
         NameKey key4 = this.analyser.analyse(instance4);
         assertNull(provider.forbid(instance1, key1));
         assertNull(provider.forbid(instance2, key2));
@@ -147,13 +146,13 @@ public class NameProviderTest extends TestUtils {
     @Test
     public void testForbid2() {
         NameProvider provider = this.getProvider("ID-6");
-        TaxonConceptInstance instance1 = this.createInstance("ID-1", NomenclaturalCode.BOTANICAL, "Acacia dealbata", provider);
+        TaxonConceptInstance instance1 = this.createInstance("ID-1", NomenclaturalClassifier.BOTANICAL, "Acacia dealbata", provider);
         NameKey key1 = this.analyser.analyse(instance1);
-        TaxonConceptInstance instance2 = this.createInstance("ID-1", NomenclaturalCode.BOTANICAL, "Acacia", provider, TaxonomicType.EXCLUDED);
+        TaxonConceptInstance instance2 = this.createInstance("ID-1", NomenclaturalClassifier.BOTANICAL, "Acacia", provider, TaxonomicType.EXCLUDED);
         NameKey key2 = this.analyser.analyse(instance2);
-        TaxonConceptInstance instance3 = this.createInstance("ID-1", NomenclaturalCode.ZOOLOGICAL, "Macropus", provider);
+        TaxonConceptInstance instance3 = this.createInstance("ID-1", NomenclaturalClassifier.ZOOLOGICAL, "Macropus", provider);
         NameKey key3 = this.analyser.analyse(instance3);
-        TaxonConceptInstance instance4 = this.createInstance("ID-1", NomenclaturalCode.ZOOLOGICAL, "Macropus", provider, TaxonomicType.INCERTAE_SEDIS);
+        TaxonConceptInstance instance4 = this.createInstance("ID-1", NomenclaturalClassifier.ZOOLOGICAL, "Macropus", provider, TaxonomicType.INCERTAE_SEDIS);
         NameKey key4 = this.analyser.analyse(instance4);
         assertNull(provider.forbid(instance1, key1));
         assertEquals("taxonomicStatus:EXCLUDED", provider.forbid(instance2, key2));

--- a/ala-name-matching-builder/src/test/java/au/org/ala/names/index/NomenclaturalClassifierTest.java
+++ b/ala-name-matching-builder/src/test/java/au/org/ala/names/index/NomenclaturalClassifierTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2021 Atlas of Living Australia
+ * All Rights Reserved.
+ *
+ * The contents of this file are subject to the Mozilla Public
+ * License Version 1.1 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.mozilla.org/MPL/
+ *
+ * Software distributed under the License is distributed on an "AS
+ *  IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ *
+ */
+
+package au.org.ala.names.index;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.gbif.api.vocabulary.NomenclaturalCode;
+import org.junit.Test;
+
+import java.io.StringWriter;
+
+import static org.junit.Assert.*;
+
+public class NomenclaturalClassifierTest {
+
+    @Test
+    public void testFind1() {
+        NomenclaturalClassifier classifier = NomenclaturalClassifier.find("ICBN");
+        assertEquals("ICBN", classifier.getAcronym());
+        assertEquals("International Code of Botanical Nomenclature", classifier.getTitle());
+        assertNotNull(classifier.getSource());
+        assertEquals("http://ibot.sav.sk/icbn/main.htm", classifier.getSource().toString());
+        assertNotNull(classifier.getAliases());
+        assertEquals(2, classifier.getAliases().size());
+        assertTrue(classifier.getAliases().contains("ICN"));
+        assertNotNull(classifier.getParent());
+        assertEquals("EUK", classifier.getParent().getAcronym());
+        assertEquals(NomenclaturalCode.BOTANICAL, classifier.getCode());
+    }
+
+    @Test
+    public void testFind2() {
+        NomenclaturalClassifier classifier = NomenclaturalClassifier.find("ICN");
+        assertEquals("ICBN", classifier.getAcronym());
+    }
+
+    @Test
+    public void testFind3() {
+        NomenclaturalClassifier classifier = NomenclaturalClassifier.find("ICNB");
+        assertEquals("ICNB", classifier.getAcronym());
+        assertEquals("International Code of Nomenclature of Bacteria", classifier.getTitle());
+        assertNotNull(classifier.getSource());
+        assertEquals("http://www.ncbi.nlm.nih.gov/books/NBK8808/", classifier.getSource().toString());
+        assertNotNull(classifier.getAliases());
+        assertEquals(1, classifier.getAliases().size());
+        assertTrue(classifier.getAliases().contains("NCGN"));
+        assertNull(classifier.getParent());
+        assertEquals(NomenclaturalCode.BACTERIAL, classifier.getCode());
+    }
+
+    @Test
+    public void testFind4() {
+        NomenclaturalClassifier classifier = NomenclaturalClassifier.find("XXXX");
+        assertNull(classifier);
+    }
+
+
+    @Test
+    public void testFind5() {
+        NomenclaturalClassifier classifier = NomenclaturalClassifier.find("BOTANICAL");
+        assertNotNull(classifier);
+        assertEquals("ICBN", classifier.getAcronym());
+    }
+
+    @Test
+    public void testFind6() {
+        NomenclaturalClassifier classifier = NomenclaturalClassifier.find(NomenclaturalCode.ZOOLOGICAL);
+        assertNotNull(classifier);
+        assertEquals("ICZN", classifier.getAcronym());
+    }
+
+    @Test
+    public void testToString1() {
+        NomenclaturalClassifier classifier = NomenclaturalClassifier.find("ICBN");
+        assertEquals("ICBN", classifier.toString());
+    }
+
+    @Test
+    public void testToJson1() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        StringWriter sw = new StringWriter();
+        NomenclaturalClassifier classifier = NomenclaturalClassifier.ZOOLOGICAL;
+        mapper.writeValue(sw, classifier);
+        assertEquals("\"ICZN\"", sw.toString());
+    }
+
+    @Test
+    public void testFromJson1() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        NomenclaturalClassifier classifier = mapper.readValue("\"ICZN\"", NomenclaturalClassifier.class);
+        assertNotNull(classifier);
+        assertEquals("ICZN", classifier.getAcronym());
+    }
+
+
+    @Test
+    public void testFromJson2() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        NomenclaturalClassifier classifier = mapper.readValue("null", NomenclaturalClassifier.class);
+        assertNull(classifier);
+    }
+
+
+}

--- a/ala-name-matching-builder/src/test/java/au/org/ala/names/index/ScientificNameTest.java
+++ b/ala-name-matching-builder/src/test/java/au/org/ala/names/index/ScientificNameTest.java
@@ -18,7 +18,6 @@ package au.org.ala.names.index;
 
 import au.org.ala.names.model.RankType;
 import au.org.ala.names.model.TaxonomicType;
-import org.gbif.api.vocabulary.NomenclaturalCode;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -54,8 +53,8 @@ public class ScientificNameTest {
     public void testAddInstance1() throws Exception {
         TaxonConceptInstance instance = new TaxonConceptInstance(
                 TAXON_ID,
-                NomenclaturalCode.ZOOLOGICAL,
-                NomenclaturalCode.ZOOLOGICAL.getAcronym(),
+                NomenclaturalClassifier.ZOOLOGICAL,
+                NomenclaturalClassifier.ZOOLOGICAL.getAcronym(),
                 provider,
                 NAME_1,
                 AUTHOR_1,
@@ -74,9 +73,10 @@ public class ScientificNameTest {
                 null,
                 null,
                 null,
+                null,
                 null
         );
-        NameKey instanceKey = this.analyser.analyse(NomenclaturalCode.ZOOLOGICAL, NAME_1, AUTHOR_1, RankType.SPECIES, null, false);
+        NameKey instanceKey = this.analyser.analyse(NomenclaturalClassifier.ZOOLOGICAL, NAME_1, AUTHOR_1, RankType.SPECIES, null, null, false);
         NameKey nameKey = instanceKey.toNameKey();
         ScientificName name = new ScientificName(null, nameKey);
         name.addInstance(instanceKey, instance);

--- a/ala-name-matching-builder/src/test/java/au/org/ala/names/index/TaxonConceptTest.java
+++ b/ala-name-matching-builder/src/test/java/au/org/ala/names/index/TaxonConceptTest.java
@@ -18,7 +18,6 @@ package au.org.ala.names.index;
 
 import au.org.ala.names.model.RankType;
 import au.org.ala.names.model.TaxonomicType;
-import org.gbif.api.vocabulary.NomenclaturalCode;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -50,8 +49,8 @@ public class TaxonConceptTest {
     public void testAddInstance1() throws Exception {
         TaxonConceptInstance instance = new TaxonConceptInstance(
                 TAXON_ID,
-                NomenclaturalCode.ZOOLOGICAL,
-                NomenclaturalCode.ZOOLOGICAL.getAcronym(),
+                NomenclaturalClassifier.ZOOLOGICAL,
+                NomenclaturalClassifier.ZOOLOGICAL.getAcronym(),
                 provider,
                 NAME_1,
                 AUTHOR_1,
@@ -70,9 +69,10 @@ public class TaxonConceptTest {
                 null,
                 null,
                 null,
+                null,
                 null
         );
-        NameKey instanceKey = this.analyser.analyse(NomenclaturalCode.ZOOLOGICAL, NAME_1, AUTHOR_1, RankType.SPECIES, null, false);
+        NameKey instanceKey = this.analyser.analyse(NomenclaturalClassifier.ZOOLOGICAL, NAME_1, AUTHOR_1, RankType.SPECIES, null, null, false);
         NameKey nameKey = instanceKey.toNameKey();
         ScientificName name = new ScientificName(null, nameKey);
         TaxonConcept concept = new TaxonConcept(name, nameKey);

--- a/ala-name-matching-builder/src/test/java/au/org/ala/names/index/TaxonomyConfiugrationTest.java
+++ b/ala-name-matching-builder/src/test/java/au/org/ala/names/index/TaxonomyConfiugrationTest.java
@@ -18,7 +18,6 @@ package au.org.ala.names.index;
 
 import au.org.ala.names.util.TestUtils;
 import org.gbif.api.model.registry.Contact;
-import org.gbif.api.vocabulary.NomenclaturalCode;
 import org.gbif.checklistbank.authorship.AuthorComparator;
 import org.gbif.checklistbank.model.Equality;
 import org.junit.Test;
@@ -128,7 +127,7 @@ public class TaxonomyConfiugrationTest extends TestUtils {
         NameProvider provider = config.providers.get(0);
         assertEquals(ID_1, provider.getId());
         assertEquals(ALANameAnalyser.class, config.nameAnalyserClass);
-        TaxonConceptInstance instance = this.createInstance(ID_2, NomenclaturalCode.BOTANICAL, NAME_1, provider);
+        TaxonConceptInstance instance = this.createInstance(ID_2, NomenclaturalClassifier.BOTANICAL, NAME_1, provider);
         assertEquals(PRIORITY_1, provider.computeScore(instance));
         assertEquals(provider, config.defaultProvider);
     }

--- a/ala-name-matching-builder/src/test/java/au/org/ala/names/index/TaxonomyTest.java
+++ b/ala-name-matching-builder/src/test/java/au/org/ala/names/index/TaxonomyTest.java
@@ -529,7 +529,7 @@ public class TaxonomyTest extends TestUtils {
         assertEquals(12, this.rowCount(new File(dir, "taxon.txt")));
         assertEquals(22, this.rowCount(new File(dir, "taxonvariant.txt")));
         assertEquals(52, this.rowCount(new File(dir, "identifier.txt")));
-        assertEquals(19, this.rowCount(new File(dir, "rightsholder.txt")));
+        assertEquals(21, this.rowCount(new File(dir, "rightsholder.txt")));
 
     }
 
@@ -550,7 +550,7 @@ public class TaxonomyTest extends TestUtils {
         assertEquals(5, this.rowCount(new File(dir, "taxon.txt")));
         assertEquals(6, this.rowCount(new File(dir, "taxonvariant.txt")));
         assertEquals(6, this.rowCount(new File(dir, "identifier.txt")));
-        assertEquals(20, this.rowCount(new File(dir, "rightsholder.txt")));
+        assertEquals(22, this.rowCount(new File(dir, "rightsholder.txt")));
     }
 
 
@@ -700,7 +700,7 @@ public class TaxonomyTest extends TestUtils {
         assertEquals(6, this.rowCount(new File(dir, "taxon.txt")));
         assertEquals(11, this.rowCount(new File(dir, "taxonvariant.txt")));
         assertEquals(11, this.rowCount(new File(dir, "identifier.txt")));
-        assertEquals(19, this.rowCount(new File(dir, "rightsholder.txt")));
+        assertEquals(21, this.rowCount(new File(dir, "rightsholder.txt")));
     }
 
     // Test the presence of a taxon loop
@@ -910,6 +910,23 @@ public class TaxonomyTest extends TestUtils {
         assertSame(tci4, tc4.getRepresentative());
         assertSame(tci5, tc5.getResolved(tci5));
         assertSame(tci5, tc5.getRepresentative());
+    }
+
+
+    @Test
+    public void testFuzzyCode1() throws Exception {
+        TaxonomyConfiguration config = TaxonomyConfiguration.read(this.resourceReader("taxonomy-config-2.json"));
+        this.taxonomy = new Taxonomy(config, null);
+        this.taxonomy.begin();
+        CSVNameSource source1 = new CSVNameSource(this.resourceReader("taxonomy-33.csv"), DwcTerm.Taxon);
+        this.taxonomy.load(Arrays.asList(source1));
+        this.taxonomy.resolve();
+        TaxonConceptInstance tci1 = this.taxonomy.getInstance("Concept-1-1");
+        TaxonConceptInstance tci2 = this.taxonomy.getInstance("Concept-1-2");
+        TaxonConcept tc1 = tci1.getContainer();
+        TaxonConcept tc2 = tci2.getContainer();
+        assertSame(tc1, tc2);
+        assertSame(tci2, tc1.getRepresentative());
     }
 
 }

--- a/ala-name-matching-builder/src/test/java/au/org/ala/names/index/provider/AndTaxonConditionTest.java
+++ b/ala-name-matching-builder/src/test/java/au/org/ala/names/index/provider/AndTaxonConditionTest.java
@@ -16,15 +16,11 @@
 
 package au.org.ala.names.index.provider;
 
-import au.org.ala.names.index.ALANameAnalyser;
-import au.org.ala.names.index.NameKey;
-import au.org.ala.names.index.NameProvider;
-import au.org.ala.names.index.TaxonConceptInstance;
+import au.org.ala.names.index.*;
 import au.org.ala.names.model.TaxonomicType;
 import au.org.ala.names.util.TestUtils;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
-import org.gbif.api.vocabulary.NomenclaturalCode;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -54,9 +50,9 @@ public class AndTaxonConditionTest extends TestUtils {
     public void testMatch1() {
         AndTaxonCondition condition = new AndTaxonCondition();
         MatchTaxonCondition condition1 = new MatchTaxonCondition();
-        condition1.setNomenclaturalCode(NomenclaturalCode.BOTANICAL);
+        condition1.setNomenclaturalCode(NomenclaturalClassifier.BOTANICAL);
         condition.add(condition1);
-        TaxonConceptInstance instance = this.createInstance("ID-1", NomenclaturalCode.BOTANICAL, "Acacia dealbata", this.provider, TaxonomicType.HOMOTYPIC_SYNONYM);
+        TaxonConceptInstance instance = this.createInstance("ID-1", NomenclaturalClassifier.BOTANICAL, "Acacia dealbata", this.provider, TaxonomicType.HOMOTYPIC_SYNONYM);
         NameKey key = this.analyser.analyse(instance);
         assertTrue(condition.match(instance, key));
     }
@@ -65,9 +61,9 @@ public class AndTaxonConditionTest extends TestUtils {
     public void testMatch2() {
         AndTaxonCondition condition = new AndTaxonCondition();
         MatchTaxonCondition condition1 = new MatchTaxonCondition();
-        condition1.setNomenclaturalCode(NomenclaturalCode.ZOOLOGICAL);
+        condition1.setNomenclaturalCode(NomenclaturalClassifier.ZOOLOGICAL);
         condition.add(condition1);
-        TaxonConceptInstance instance = this.createInstance("ID-1", NomenclaturalCode.BOTANICAL, "Acacia dealbata", this.provider, TaxonomicType.HOMOTYPIC_SYNONYM);
+        TaxonConceptInstance instance = this.createInstance("ID-1", NomenclaturalClassifier.BOTANICAL, "Acacia dealbata", this.provider, TaxonomicType.HOMOTYPIC_SYNONYM);
         NameKey key = this.analyser.analyse(instance);
         assertFalse(condition.match(instance, key));
     }
@@ -77,12 +73,12 @@ public class AndTaxonConditionTest extends TestUtils {
     public void testMatch3() {
         AndTaxonCondition condition = new AndTaxonCondition();
         MatchTaxonCondition condition1 = new MatchTaxonCondition();
-        condition1.setNomenclaturalCode(NomenclaturalCode.BOTANICAL);
+        condition1.setNomenclaturalCode(NomenclaturalClassifier.BOTANICAL);
         MatchTaxonCondition condition2 = new MatchTaxonCondition();
         condition2.setTaxonomicStatus(TaxonomicType.HOMOTYPIC_SYNONYM);
         condition.add(condition1);
         condition.add(condition2);
-        TaxonConceptInstance instance = this.createInstance("ID-1", NomenclaturalCode.BOTANICAL, "Acacia dealbata", this.provider, TaxonomicType.HOMOTYPIC_SYNONYM);
+        TaxonConceptInstance instance = this.createInstance("ID-1", NomenclaturalClassifier.BOTANICAL, "Acacia dealbata", this.provider, TaxonomicType.HOMOTYPIC_SYNONYM);
         NameKey key = this.analyser.analyse(instance);
         assertTrue(condition.match(instance, key));
     }
@@ -91,12 +87,12 @@ public class AndTaxonConditionTest extends TestUtils {
     public void testMatch4() {
         AndTaxonCondition condition = new AndTaxonCondition();
         MatchTaxonCondition condition1 = new MatchTaxonCondition();
-        condition1.setNomenclaturalCode(NomenclaturalCode.BOTANICAL);
+        condition1.setNomenclaturalCode(NomenclaturalClassifier.BOTANICAL);
         MatchTaxonCondition condition2 = new MatchTaxonCondition();
         condition2.setTaxonomicStatus(TaxonomicType.HOMOTYPIC_SYNONYM);
         condition.add(condition1);
         condition.add(condition2);
-        TaxonConceptInstance instance = this.createInstance("ID-1", NomenclaturalCode.ZOOLOGICAL, "Acacia dealbata", this.provider, TaxonomicType.HOMOTYPIC_SYNONYM);
+        TaxonConceptInstance instance = this.createInstance("ID-1", NomenclaturalClassifier.ZOOLOGICAL, "Acacia dealbata", this.provider, TaxonomicType.HOMOTYPIC_SYNONYM);
         NameKey key = this.analyser.analyse(instance);
         assertFalse(condition.match(instance, key));
     }
@@ -105,12 +101,12 @@ public class AndTaxonConditionTest extends TestUtils {
     public void testMatch5() {
         AndTaxonCondition condition = new AndTaxonCondition();
         MatchTaxonCondition condition1 = new MatchTaxonCondition();
-        condition1.setNomenclaturalCode(NomenclaturalCode.BOTANICAL);
+        condition1.setNomenclaturalCode(NomenclaturalClassifier.BOTANICAL);
         MatchTaxonCondition condition2 = new MatchTaxonCondition();
         condition2.setTaxonomicStatus(TaxonomicType.HOMOTYPIC_SYNONYM);
         condition.add(condition1);
         condition.add(condition2);
-        TaxonConceptInstance instance = this.createInstance("ID-1", NomenclaturalCode.BOTANICAL, "Acacia dealbata", this.provider, TaxonomicType.ACCEPTED);
+        TaxonConceptInstance instance = this.createInstance("ID-1", NomenclaturalClassifier.BOTANICAL, "Acacia dealbata", this.provider, TaxonomicType.ACCEPTED);
         NameKey key = this.analyser.analyse(instance);
         assertFalse(condition.match(instance, key));
     }
@@ -119,7 +115,7 @@ public class AndTaxonConditionTest extends TestUtils {
     public void testWrite1() throws Exception {
         AndTaxonCondition condition = new AndTaxonCondition();
         MatchTaxonCondition condition1 = new MatchTaxonCondition();
-        condition1.setNomenclaturalCode(NomenclaturalCode.BOTANICAL);
+        condition1.setNomenclaturalCode(NomenclaturalClassifier.BOTANICAL);
         MatchTaxonCondition condition2 = new MatchTaxonCondition();
         condition2.setTaxonomicStatus(TaxonomicType.HOMOTYPIC_SYNONYM);
         condition.add(condition1);
@@ -135,10 +131,10 @@ public class AndTaxonConditionTest extends TestUtils {
     public void testRead1() throws Exception {
         ObjectMapper mapper = new ObjectMapper();
         AndTaxonCondition condition = mapper.readValue(this.resourceReader("and-condition-1.json"), AndTaxonCondition.class);
-        TaxonConceptInstance instance = this.createInstance("ID-1", NomenclaturalCode.BOTANICAL, "Acacia dealbata", this.provider, TaxonomicType.HOMOTYPIC_SYNONYM);
+        TaxonConceptInstance instance = this.createInstance("ID-1", NomenclaturalClassifier.BOTANICAL, "Acacia dealbata", this.provider, TaxonomicType.HOMOTYPIC_SYNONYM);
         NameKey key = this.analyser.analyse(instance);
         assertTrue(condition.match(instance, key));
-        instance = this.createInstance("ID-1", NomenclaturalCode.BOTANICAL, "Acacia dealbata", this.provider, TaxonomicType.ACCEPTED);
+        instance = this.createInstance("ID-1", NomenclaturalClassifier.BOTANICAL, "Acacia dealbata", this.provider, TaxonomicType.ACCEPTED);
         key = this.analyser.analyse(instance);
         assertFalse(condition.match(instance, key));
     }

--- a/ala-name-matching-builder/src/test/java/au/org/ala/names/index/provider/KeyAdjusterTest.java
+++ b/ala-name-matching-builder/src/test/java/au/org/ala/names/index/provider/KeyAdjusterTest.java
@@ -47,34 +47,34 @@ public class KeyAdjusterTest extends TestUtils {
         condition1.setScientificName("Viruses");
         this.adjuster.addAdjustment(new KeyAdjustment(condition1, null, "VIRUS", null, null, null));
         MatchTaxonCondition condition2 = new MatchTaxonCondition();
-        condition2.setNomenclaturalCode(NomenclaturalCode.PHYLOCODE);
-        this.adjuster.addAdjustment(new KeyAdjustment(condition2, NomenclaturalCode.BACTERIAL, null, "", null, null));
+        condition2.setNomenclaturalCode(NomenclaturalClassifier.find(NomenclaturalCode.PHYLOCODE));
+        this.adjuster.addAdjustment(new KeyAdjustment(condition2, NomenclaturalClassifier.BACTERIAL, null, "", null, null));
         MatchTaxonCondition condition3 = new MatchTaxonCondition();
         condition3.setTaxonRank(RankType.DOMAIN);
-        this.adjuster.addAdjustment(new KeyAdjustment(condition3, NomenclaturalCode.CULTIVARS, "PLACEHOLDER", "Nurke", NameType.CULTIVAR, RankType.CULTIVAR));
+        this.adjuster.addAdjustment(new KeyAdjustment(condition3, NomenclaturalClassifier.CULTIVARS, "PLACEHOLDER", "Nurke", NameType.CULTIVAR, RankType.CULTIVAR));
     }
 
 
     @Test
     public void testAdjust1() {
-        TaxonConceptInstance instance = this.createInstance("ID-1", NomenclaturalCode.ZOOLOGICAL, "Osphranter rufus", this.provider, TaxonomicType.ACCEPTED );
-        NameKey key = this.analyser.analyse(instance.getCode(), instance.getScientificName(), instance.getScientificNameAuthorship(), instance.getRank(), null, false);
+        TaxonConceptInstance instance = this.createInstance("ID-1", NomenclaturalClassifier.ZOOLOGICAL, "Osphranter rufus", this.provider, TaxonomicType.ACCEPTED );
+        NameKey key = this.analyser.analyse(instance.getCode(), instance.getScientificName(), instance.getScientificNameAuthorship(), instance.getRank(), null, null, false);
         NameKey key2 = this.adjuster.adjustKey(key, instance);
         assertSame(key, key2);
     }
 
     @Test
     public void testAdjust2() {
-        TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalCode.BOTANICAL, NomenclaturalCode.BOTANICAL.getAcronym(), this.provider,"Acacia dealbata", "Link.", null,null, TaxonomicType.MISAPPLIED, TaxonomicType.MISAPPLIED.getTerm(), RankType.SPECIES,  RankType.SPECIES.getRank(), null, null,null, null, null, null, null, null, null, null);
-        NameKey key = this.analyser.analyse(instance.getCode(), instance.getScientificName(), instance.getScientificNameAuthorship(), instance.getRank(), null, false);
+        TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalClassifier.BOTANICAL, NomenclaturalClassifier.BOTANICAL.getAcronym(), this.provider,"Acacia dealbata", "Link.", null,null, TaxonomicType.MISAPPLIED, TaxonomicType.MISAPPLIED.getTerm(), RankType.SPECIES,  RankType.SPECIES.getRank(), null, null,null, null, null, null, null, null, null, null, null);
+        NameKey key = this.analyser.analyse(instance.getCode(), instance.getScientificName(), instance.getScientificNameAuthorship(), instance.getRank(), null, null, false);
         NameKey key2 = this.adjuster.adjustKey(key, instance);
         assertSame(key, key2);
     }
 
     @Test
     public void testAdjust3() {
-        TaxonConceptInstance instance = this.createInstance("ID-1", NomenclaturalCode.VIRUS, "Viruses", this.provider, TaxonomicType.ACCEPTED );
-        NameKey key = this.analyser.analyse(instance.getCode(), instance.getScientificName(), instance.getScientificNameAuthorship(), instance.getRank(), null, false);
+        TaxonConceptInstance instance = this.createInstance("ID-1", NomenclaturalClassifier.VIRUS, "Viruses", this.provider, TaxonomicType.ACCEPTED );
+        NameKey key = this.analyser.analyse(instance.getCode(), instance.getScientificName(), instance.getScientificNameAuthorship(), instance.getRank(), null, null, false);
         NameKey key2 = this.adjuster.adjustKey(key, instance);
         assertNotSame(key, key2);
         assertEquals(key.getCode(), key2.getCode());
@@ -86,11 +86,11 @@ public class KeyAdjusterTest extends TestUtils {
 
     @Test
     public void testAdjust4() {
-        TaxonConceptInstance instance = this.createInstance("ID-1", NomenclaturalCode.PHYLOCODE, "Viruses", this.provider, TaxonomicType.MISAPPLIED );
-        NameKey key = this.analyser.analyse(instance.getCode(), instance.getScientificName(), instance.getScientificNameAuthorship(), instance.getRank(), null, false);
+        TaxonConceptInstance instance = this.createInstance("ID-1", NomenclaturalClassifier.find(NomenclaturalCode.PHYLOCODE), "Viruses", this.provider, TaxonomicType.MISAPPLIED );
+        NameKey key = this.analyser.analyse(instance.getCode(), instance.getScientificName(), instance.getScientificNameAuthorship(), instance.getRank(), null, null, false);
         NameKey key2 = this.adjuster.adjustKey(key, instance);
         assertNotSame(key, key2);
-        assertEquals(NomenclaturalCode.BACTERIAL, key2.getCode());
+        assertEquals(NomenclaturalClassifier.BACTERIAL, key2.getCode());
         assertEquals("VIRUS", key2.getScientificName());
         assertEquals(key.getScientificNameAuthorship(), key2.getScientificNameAuthorship());
         assertEquals(key.getType(), key2.getType());
@@ -99,11 +99,11 @@ public class KeyAdjusterTest extends TestUtils {
 
     @Test
     public void testAdjust5() {
-        TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalCode.PHYLOCODE, NomenclaturalCode.PHYLOCODE.getAcronym(), this.provider,"Acacia dealbata", "Link.", null,null, TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES,  RankType.SPECIES.getRank(), null, null,null, null, null, null, null, null, null, null);
-        NameKey key = this.analyser.analyse(instance.getCode(), instance.getScientificName(), instance.getScientificNameAuthorship(), instance.getRank(), null, false);
+        TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalClassifier.find(NomenclaturalCode.PHYLOCODE), NomenclaturalCode.PHYLOCODE.getAcronym(), this.provider,"Acacia dealbata", "Link.", null,null, TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES,  RankType.SPECIES.getRank(), null, null,null, null, null, null, null, null, null, null, null);
+        NameKey key = this.analyser.analyse(instance.getCode(), instance.getScientificName(), instance.getScientificNameAuthorship(), instance.getRank(), null, null, false);
         NameKey key2 = this.adjuster.adjustKey(key, instance);
         assertNotSame(key, key2);
-        assertEquals(NomenclaturalCode.BACTERIAL, key2.getCode());
+        assertEquals(NomenclaturalClassifier.BACTERIAL, key2.getCode());
         assertEquals(key.getScientificName(), key2.getScientificName());
         assertNull(key2.getScientificNameAuthorship());
         assertEquals(key.getType(), key2.getType());
@@ -113,11 +113,11 @@ public class KeyAdjusterTest extends TestUtils {
 
     @Test
     public void testAdjust6() {
-        TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalCode.BOTANICAL, NomenclaturalCode.BOTANICAL.getAcronym(), this.provider,"Acacia dealbata", "Link.", null,null, TaxonomicType.MISAPPLIED, TaxonomicType.MISAPPLIED.getTerm(), RankType.DOMAIN,  RankType.DOMAIN.getRank(), null, null,null, null, null, null, null, null, null, null);
-        NameKey key = this.analyser.analyse(instance.getCode(), instance.getScientificName(), instance.getScientificNameAuthorship(), instance.getRank(), null, false);
+        TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalClassifier.BOTANICAL, NomenclaturalClassifier.BOTANICAL.getAcronym(), this.provider,"Acacia dealbata", "Link.", null,null, TaxonomicType.MISAPPLIED, TaxonomicType.MISAPPLIED.getTerm(), RankType.DOMAIN,  RankType.DOMAIN.getRank(), null, null,null, null, null, null, null, null, null, null, null);
+        NameKey key = this.analyser.analyse(instance.getCode(), instance.getScientificName(), instance.getScientificNameAuthorship(), instance.getRank(), null, null, false);
         NameKey key2 = this.adjuster.adjustKey(key, instance);
         assertNotSame(key, key2);
-        assertEquals(NomenclaturalCode.CULTIVARS, key2.getCode());
+        assertEquals(NomenclaturalClassifier.CULTIVARS, key2.getCode());
         assertEquals("PLACEHOLDER", key2.getScientificName());
         assertEquals("Nurke", key2.getScientificNameAuthorship());
         assertEquals(NameType.CULTIVAR, key2.getType());

--- a/ala-name-matching-builder/src/test/java/au/org/ala/names/index/provider/MatchTaxonConditionTest.java
+++ b/ala-name-matching-builder/src/test/java/au/org/ala/names/index/provider/MatchTaxonConditionTest.java
@@ -18,12 +18,12 @@ package au.org.ala.names.index.provider;
 
 import au.org.ala.names.index.*;
 import au.org.ala.names.model.RankType;
+import au.org.ala.names.model.TaxonFlag;
 import au.org.ala.names.model.TaxonomicType;
 import au.org.ala.names.util.TestUtils;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import org.gbif.api.vocabulary.NameType;
-import org.gbif.api.vocabulary.NomenclaturalCode;
 import org.gbif.api.vocabulary.NomenclaturalStatus;
 import org.junit.Before;
 import org.junit.Test;
@@ -52,8 +52,8 @@ public class MatchTaxonConditionTest extends TestUtils {
     @Test
     public void testMatch1() {
         MatchTaxonCondition condition = new MatchTaxonCondition();
-        condition.setNomenclaturalCode(NomenclaturalCode.BOTANICAL);
-        TaxonConceptInstance instance = this.createInstance("ID-1", NomenclaturalCode.BOTANICAL, "Acacia dealbata", this.provider, TaxonomicType.HOMOTYPIC_SYNONYM);
+        condition.setNomenclaturalCode(NomenclaturalClassifier.BOTANICAL);
+        TaxonConceptInstance instance = this.createInstance("ID-1", NomenclaturalClassifier.BOTANICAL, "Acacia dealbata", this.provider, TaxonomicType.HOMOTYPIC_SYNONYM);
         NameKey key = this.analyser.analyse(instance);
         assertTrue(condition.match(instance, key));
     }
@@ -61,8 +61,8 @@ public class MatchTaxonConditionTest extends TestUtils {
     @Test
     public void testMatch2() {
         MatchTaxonCondition condition = new MatchTaxonCondition();
-        condition.setNomenclaturalCode(NomenclaturalCode.ZOOLOGICAL);
-        TaxonConceptInstance instance = this.createInstance("ID-1", NomenclaturalCode.BOTANICAL, "Acacia dealbata", this.provider, TaxonomicType.HOMOTYPIC_SYNONYM);
+        condition.setNomenclaturalCode(NomenclaturalClassifier.ZOOLOGICAL);
+        TaxonConceptInstance instance = this.createInstance("ID-1", NomenclaturalClassifier.BOTANICAL, "Acacia dealbata", this.provider, TaxonomicType.HOMOTYPIC_SYNONYM);
         NameKey key = this.analyser.analyse(instance);
         assertFalse(condition.match(instance, key));
     }
@@ -71,7 +71,7 @@ public class MatchTaxonConditionTest extends TestUtils {
     public void testMatch3() {
         MatchTaxonCondition condition = new MatchTaxonCondition();
         condition.setTaxonomicStatus(TaxonomicType.HOMOTYPIC_SYNONYM);
-        TaxonConceptInstance instance = this.createInstance("ID-1", NomenclaturalCode.BOTANICAL,  "Acacia dealbata", this.provider, TaxonomicType.HOMOTYPIC_SYNONYM);
+        TaxonConceptInstance instance = this.createInstance("ID-1", NomenclaturalClassifier.BOTANICAL,  "Acacia dealbata", this.provider, TaxonomicType.HOMOTYPIC_SYNONYM);
         NameKey key = this.analyser.analyse(instance);
         assertTrue(condition.match(instance, key));
     }
@@ -80,7 +80,7 @@ public class MatchTaxonConditionTest extends TestUtils {
     public void testMatch4() {
         MatchTaxonCondition condition = new MatchTaxonCondition();
         condition.setTaxonomicStatus(TaxonomicType.ACCEPTED);
-        TaxonConceptInstance instance = this.createInstance("ID-1", NomenclaturalCode.BOTANICAL, "Acacia dealbata", this.provider, TaxonomicType.HOMOTYPIC_SYNONYM);
+        TaxonConceptInstance instance = this.createInstance("ID-1", NomenclaturalClassifier.BOTANICAL, "Acacia dealbata", this.provider, TaxonomicType.HOMOTYPIC_SYNONYM);
         NameKey key = this.analyser.analyse(instance);
         assertFalse(condition.match(instance, key));
     }
@@ -89,7 +89,7 @@ public class MatchTaxonConditionTest extends TestUtils {
     public void testMatch5() {
         MatchTaxonCondition condition = new MatchTaxonCondition();
         condition.setNomenclaturalStatus(NomenclaturalStatus.DOUBTFUL);
-        TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalCode.BOTANICAL, NomenclaturalCode.BOTANICAL.getAcronym(), this.provider, "Acacia dealbata", null, null,null, TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), Collections.singleton(NomenclaturalStatus.DOUBTFUL), "doubtful", null, null, null, null, null, null, null, null);
+        TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalClassifier.BOTANICAL, NomenclaturalClassifier.BOTANICAL.getAcronym(), this.provider, "Acacia dealbata", null, null,null, TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), Collections.singleton(NomenclaturalStatus.DOUBTFUL), "doubtful", null, null, null, null, null, null, null, null, null);
         NameKey key = this.analyser.analyse(instance);
         assertTrue(condition.match(instance, key));
     }
@@ -98,7 +98,7 @@ public class MatchTaxonConditionTest extends TestUtils {
     public void testMatch6() {
         MatchTaxonCondition condition = new MatchTaxonCondition();
         condition.setNomenclaturalStatus(NomenclaturalStatus.DOUBTFUL);
-        TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalCode.BOTANICAL, NomenclaturalCode.BOTANICAL.getAcronym(), this.provider, "Acacia dealbata", null, null, null, TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(),null, null,null, null, null, null, null, null, null, null);
+        TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalClassifier.BOTANICAL, NomenclaturalClassifier.BOTANICAL.getAcronym(), this.provider, "Acacia dealbata", null, null, null, TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(),null, null,null, null, null, null, null, null, null, null, null);
         NameKey key = this.analyser.analyse(instance);
         assertFalse(condition.match(instance, key));
     }
@@ -107,7 +107,7 @@ public class MatchTaxonConditionTest extends TestUtils {
     public void testMatch7() {
         MatchTaxonCondition condition = new MatchTaxonCondition();
         condition.setNomenclaturalStatus(NomenclaturalStatus.DOUBTFUL);
-        TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalCode.BOTANICAL, NomenclaturalCode.BOTANICAL.getAcronym(), this.provider, "Acacia dealbata", null, null, null, TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), Collections.singleton(NomenclaturalStatus.ALTERNATIVE), "alternative", null, null, null, null, null, null, null, null);
+        TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalClassifier.BOTANICAL, NomenclaturalClassifier.BOTANICAL.getAcronym(), this.provider, "Acacia dealbata", null, null, null, TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), Collections.singleton(NomenclaturalStatus.ALTERNATIVE), "alternative", null, null, null, null, null, null, null, null, null);
         NameKey key = this.analyser.analyse(instance);
         assertFalse(condition.match(instance, key));
     }
@@ -116,7 +116,7 @@ public class MatchTaxonConditionTest extends TestUtils {
     public void testMatch8() {
         MatchTaxonCondition condition = new MatchTaxonCondition();
         condition.setNameType(NameType.SCIENTIFIC);
-        TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalCode.BOTANICAL, NomenclaturalCode.BOTANICAL.getAcronym(), this.provider, "Acacia dealbata", null, null,null, TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null);
+        TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalClassifier.BOTANICAL, NomenclaturalClassifier.BOTANICAL.getAcronym(), this.provider, "Acacia dealbata", null, null,null, TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null, null);
         NameKey key = this.analyser.analyse(instance);
         assertTrue(condition.match(instance, key));
     }
@@ -125,7 +125,7 @@ public class MatchTaxonConditionTest extends TestUtils {
     public void testMatch9() {
         MatchTaxonCondition condition = new MatchTaxonCondition();
         condition.setNameType(NameType.SCIENTIFIC);
-        TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalCode.BOTANICAL, NomenclaturalCode.BOTANICAL.getAcronym(), this.provider, "Acacia unplaced", null, null,null, TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null);
+        TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalClassifier.BOTANICAL, NomenclaturalClassifier.BOTANICAL.getAcronym(), this.provider, "Acacia unplaced", null, null,null, TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null, null);
         NameKey key = this.analyser.analyse(instance);
         assertFalse(condition.match(instance, key));
     }
@@ -134,7 +134,7 @@ public class MatchTaxonConditionTest extends TestUtils {
     public void testMatch10() {
         MatchTaxonCondition condition = new MatchTaxonCondition();
         condition.setTaxonRank(RankType.SPECIES);
-        TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalCode.BOTANICAL, NomenclaturalCode.BOTANICAL.getAcronym(), this.provider, "Acacia dealbata", null, null,null, TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null);
+        TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalClassifier.BOTANICAL, NomenclaturalClassifier.BOTANICAL.getAcronym(), this.provider, "Acacia dealbata", null, null,null, TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null, null);
         NameKey key = this.analyser.analyse(instance);
         assertTrue(condition.match(instance, key));
     }
@@ -143,7 +143,7 @@ public class MatchTaxonConditionTest extends TestUtils {
     public void testMatch11() {
         MatchTaxonCondition condition = new MatchTaxonCondition();
         condition.setTaxonRank(RankType.CLASS);
-        TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalCode.BOTANICAL, NomenclaturalCode.BOTANICAL.getAcronym(), this.provider, "Acacia dealbata", null, null, null, TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null);
+        TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalClassifier.BOTANICAL, NomenclaturalClassifier.BOTANICAL.getAcronym(), this.provider, "Acacia dealbata", null, null, null, TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null, null);
         NameKey key = this.analyser.analyse(instance);
         assertFalse(condition.match(instance, key));
     }
@@ -152,7 +152,7 @@ public class MatchTaxonConditionTest extends TestUtils {
     public void testMatch12() {
         MatchTaxonCondition condition = new MatchTaxonCondition();
         condition.setYear("1974");
-        TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalCode.BOTANICAL, NomenclaturalCode.BOTANICAL.getAcronym(), this.provider, "Acacia dealbata", null, null, "1974", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null);
+        TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalClassifier.BOTANICAL, NomenclaturalClassifier.BOTANICAL.getAcronym(), this.provider, "Acacia dealbata", null, null, "1974", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null, null);
         NameKey key = this.analyser.analyse(instance);
         assertTrue(condition.match(instance, key));
     }
@@ -161,7 +161,7 @@ public class MatchTaxonConditionTest extends TestUtils {
     public void testMatch13() {
         MatchTaxonCondition condition = new MatchTaxonCondition();
         condition.setYear("1974");
-        TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalCode.BOTANICAL, NomenclaturalCode.BOTANICAL.getAcronym(), this.provider, "Acacia dealbata", null, null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null);
+        TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalClassifier.BOTANICAL, NomenclaturalClassifier.BOTANICAL.getAcronym(), this.provider, "Acacia dealbata", null, null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null, null);
         NameKey key = this.analyser.analyse(instance);
         assertFalse(condition.match(instance, key));
     }
@@ -170,7 +170,7 @@ public class MatchTaxonConditionTest extends TestUtils {
     public void testMatch14() {
         MatchTaxonCondition condition = new MatchTaxonCondition();
         condition.setScientificName("Acacia dealbata");
-        TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalCode.BOTANICAL, NomenclaturalCode.BOTANICAL.getAcronym(), this.provider, "Acacia dealbata", null, null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null);
+        TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalClassifier.BOTANICAL, NomenclaturalClassifier.BOTANICAL.getAcronym(), this.provider, "Acacia dealbata", null, null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null, null);
         NameKey key = this.analyser.analyse(instance);
         assertTrue(condition.match(instance, key));
     }
@@ -179,7 +179,7 @@ public class MatchTaxonConditionTest extends TestUtils {
     public void testMatch15() {
         MatchTaxonCondition condition = new MatchTaxonCondition();
         condition.setScientificName(" Acacia dealbata ");
-        TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalCode.BOTANICAL, NomenclaturalCode.BOTANICAL.getAcronym(), this.provider, "Acacia dealbata", null, null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null);
+        TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalClassifier.BOTANICAL, NomenclaturalClassifier.BOTANICAL.getAcronym(), this.provider, "Acacia dealbata", null, null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null, null);
         NameKey key = this.analyser.analyse(instance);
         assertTrue(condition.match(instance, key));
     }
@@ -188,7 +188,7 @@ public class MatchTaxonConditionTest extends TestUtils {
     public void testMatch16() {
         MatchTaxonCondition condition = new MatchTaxonCondition();
         condition.setScientificName("Acacia other");
-        TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalCode.BOTANICAL, NomenclaturalCode.BOTANICAL.getAcronym(), this.provider, "Acacia dealbata", null, null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null);
+        TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalClassifier.BOTANICAL, NomenclaturalClassifier.BOTANICAL.getAcronym(), this.provider, "Acacia dealbata", null, null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null, null);
         NameKey key = this.analyser.analyse(instance);
         assertFalse(condition.match(instance, key));
     }
@@ -198,7 +198,7 @@ public class MatchTaxonConditionTest extends TestUtils {
         MatchTaxonCondition condition = new MatchTaxonCondition();
         condition.setScientificName("Acacia dealbata");
         condition.setMatchType(NameMatchType.INSENSITIVE);
-        TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalCode.BOTANICAL, NomenclaturalCode.BOTANICAL.getAcronym(), this.provider, "Acacia dealbata", null, null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null);
+        TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalClassifier.BOTANICAL, NomenclaturalClassifier.BOTANICAL.getAcronym(), this.provider, "Acacia dealbata", null, null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null, null);
         NameKey key = this.analyser.analyse(instance);
         assertTrue(condition.match(instance, key));
     }
@@ -208,7 +208,7 @@ public class MatchTaxonConditionTest extends TestUtils {
         MatchTaxonCondition condition = new MatchTaxonCondition();
         condition.setScientificName(" ACACIA    dealbata ");
         condition.setMatchType(NameMatchType.INSENSITIVE);
-        TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalCode.BOTANICAL, NomenclaturalCode.BOTANICAL.getAcronym(), this.provider, "Acacia dealbata", null, null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null);
+        TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalClassifier.BOTANICAL, NomenclaturalClassifier.BOTANICAL.getAcronym(), this.provider, "Acacia dealbata", null, null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null, null);
         NameKey key = this.analyser.analyse(instance);
         assertTrue(condition.match(instance, key));
     }
@@ -218,7 +218,7 @@ public class MatchTaxonConditionTest extends TestUtils {
         MatchTaxonCondition condition = new MatchTaxonCondition();
         condition.setScientificName(" ACACIA    dealbata ");
         condition.setMatchType(NameMatchType.INSENSITIVE);
-        TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalCode.BOTANICAL, NomenclaturalCode.BOTANICAL.getAcronym(), this.provider, " ACACIA   Dealbata", null, null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null);
+        TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalClassifier.BOTANICAL, NomenclaturalClassifier.BOTANICAL.getAcronym(), this.provider, " ACACIA   Dealbata", null, null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null, null);
         NameKey key = this.analyser.analyse(instance);
         assertTrue(condition.match(instance, key));
     }
@@ -228,7 +228,7 @@ public class MatchTaxonConditionTest extends TestUtils {
         MatchTaxonCondition condition = new MatchTaxonCondition();
         condition.setScientificName("Acacia other");
         condition.setMatchType(NameMatchType.INSENSITIVE);
-        TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalCode.BOTANICAL, NomenclaturalCode.BOTANICAL.getAcronym(), this.provider, "Acacia dealbata", null, null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null);
+        TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalClassifier.BOTANICAL, NomenclaturalClassifier.BOTANICAL.getAcronym(), this.provider, "Acacia dealbata", null, null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null, null);
         NameKey key = this.analyser.analyse(instance);
         assertFalse(condition.match(instance, key));
     }
@@ -238,7 +238,7 @@ public class MatchTaxonConditionTest extends TestUtils {
         MatchTaxonCondition condition = new MatchTaxonCondition();
         condition.setScientificName("Mycofalcella calcarata");
         condition.setMatchType(NameMatchType.NORMALISED);
-        TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalCode.BOTANICAL, NomenclaturalCode.BOTANICAL.getAcronym(), this.provider, "Mycofalcela calcarata", null, null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null);
+        TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalClassifier.BOTANICAL, NomenclaturalClassifier.BOTANICAL.getAcronym(), this.provider, "Mycofalcela calcarata", null, null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null, null);
         NameKey key = this.analyser.analyse(instance);
         assertTrue(condition.match(instance, key));
     }
@@ -248,7 +248,7 @@ public class MatchTaxonConditionTest extends TestUtils {
         MatchTaxonCondition condition = new MatchTaxonCondition();
         condition.setScientificName("Aphanesia greyi");
         condition.setMatchType(NameMatchType.NORMALISED);
-        TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalCode.BOTANICAL, NomenclaturalCode.BOTANICAL.getAcronym(), this.provider, "Aphanesia grei", null, null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null);
+        TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalClassifier.BOTANICAL, NomenclaturalClassifier.BOTANICAL.getAcronym(), this.provider, "Aphanesia grei", null, null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null, null);
         NameKey key = this.analyser.analyse(instance);
         assertTrue(condition.match(instance, key));
     }
@@ -258,7 +258,7 @@ public class MatchTaxonConditionTest extends TestUtils {
         MatchTaxonCondition condition = new MatchTaxonCondition();
         condition.setScientificName("Aphanesia greyi");
         condition.setMatchType(NameMatchType.NORMALISED);
-        TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalCode.BOTANICAL, NomenclaturalCode.BOTANICAL.getAcronym(), this.provider, " Aphanesia  greyi  ", null, null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null);
+        TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalClassifier.BOTANICAL, NomenclaturalClassifier.BOTANICAL.getAcronym(), this.provider, " Aphanesia  greyi  ", null, null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null, null);
         NameKey key = this.analyser.analyse(instance);
         assertTrue(condition.match(instance, key));
     }
@@ -268,7 +268,7 @@ public class MatchTaxonConditionTest extends TestUtils {
         MatchTaxonCondition condition = new MatchTaxonCondition();
         condition.setScientificName("Aphanesia greyi");
         condition.setMatchType(NameMatchType.NORMALISED);
-        TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalCode.BOTANICAL, NomenclaturalCode.BOTANICAL.getAcronym(), this.provider, "Acacia dealbata", null, null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null);
+        TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalClassifier.BOTANICAL, NomenclaturalClassifier.BOTANICAL.getAcronym(), this.provider, "Acacia dealbata", null, null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null, null);
         NameKey key = this.analyser.analyse(instance);
         assertFalse(condition.match(instance, key));
     }
@@ -279,10 +279,10 @@ public class MatchTaxonConditionTest extends TestUtils {
         MatchTaxonCondition condition = new MatchTaxonCondition();
         condition.setScientificName("Mycofalcel+a calca?rata");
         condition.setMatchType(NameMatchType.REGEX);
-        TaxonConceptInstance instance1 = new TaxonConceptInstance("ID-1", NomenclaturalCode.BOTANICAL, NomenclaturalCode.BOTANICAL.getAcronym(), this.provider, "Mycofalcella calcarata", null, null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null);
+        TaxonConceptInstance instance1 = new TaxonConceptInstance("ID-1", NomenclaturalClassifier.BOTANICAL, NomenclaturalClassifier.BOTANICAL.getAcronym(), this.provider, "Mycofalcella calcarata", null, null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null, null);
         NameKey key1 = this.analyser.analyse(instance1);
         assertTrue(condition.match(instance1, key1));
-        TaxonConceptInstance instance2 = new TaxonConceptInstance("ID-1", NomenclaturalCode.BOTANICAL, NomenclaturalCode.BOTANICAL.getAcronym(), this.provider, "Mycofalcela calcrata", null, null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null);
+        TaxonConceptInstance instance2 = new TaxonConceptInstance("ID-1", NomenclaturalClassifier.BOTANICAL, NomenclaturalClassifier.BOTANICAL.getAcronym(), this.provider, "Mycofalcela calcrata", null, null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null, null);
         NameKey key2 = this.analyser.analyse(instance2);
         assertTrue(condition.match(instance2, key2));
     }
@@ -292,7 +292,7 @@ public class MatchTaxonConditionTest extends TestUtils {
         MatchTaxonCondition condition = new MatchTaxonCondition();
         condition.setScientificName("Aphanesia gr[eyi]+");
         condition.setMatchType(NameMatchType.REGEX);
-        TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalCode.BOTANICAL, NomenclaturalCode.BOTANICAL.getAcronym(), this.provider, "Aphanesia greyi", null, null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null);
+        TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalClassifier.BOTANICAL, NomenclaturalClassifier.BOTANICAL.getAcronym(), this.provider, "Aphanesia greyi", null, null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null, null);
         NameKey key = this.analyser.analyse(instance);
         assertTrue(condition.match(instance, key));
     }
@@ -302,7 +302,7 @@ public class MatchTaxonConditionTest extends TestUtils {
         MatchTaxonCondition condition = new MatchTaxonCondition();
         condition.setScientificName("Aphanesia gr[eyi]+");
         condition.setMatchType(NameMatchType.REGEX);
-        TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalCode.BOTANICAL, NomenclaturalCode.BOTANICAL.getAcronym(), this.provider, "Acacia dealbata", null, null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null);
+        TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalClassifier.BOTANICAL, NomenclaturalClassifier.BOTANICAL.getAcronym(), this.provider, "Acacia dealbata", null, null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null, null);
         NameKey key = this.analyser.analyse(instance);
         assertFalse(condition.match(instance, key));
     }
@@ -313,7 +313,7 @@ public class MatchTaxonConditionTest extends TestUtils {
         MatchTaxonCondition condition = new MatchTaxonCondition();
         condition.setScientificNameAuthorship("Benth.");
         condition.setMatchType(NameMatchType.EXACT);
-        TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalCode.BOTANICAL, NomenclaturalCode.BOTANICAL.getAcronym(), this.provider, "Lepidosperma leptophyllum", "Benth.", null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null);
+        TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalClassifier.BOTANICAL, NomenclaturalClassifier.BOTANICAL.getAcronym(), this.provider, "Lepidosperma leptophyllum", "Benth.", null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null, null);
         NameKey key = this.analyser.analyse(instance);
         assertTrue(condition.match(instance, key));
     }
@@ -323,7 +323,7 @@ public class MatchTaxonConditionTest extends TestUtils {
         MatchTaxonCondition condition = new MatchTaxonCondition();
         condition.setScientificNameAuthorship("Benth.");
         condition.setMatchType(NameMatchType.EXACT);
-        TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalCode.BOTANICAL, NomenclaturalCode.BOTANICAL.getAcronym(), this.provider, "Lepidosperma leptophyllum", " Benth.", null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null);
+        TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalClassifier.BOTANICAL, NomenclaturalClassifier.BOTANICAL.getAcronym(), this.provider, "Lepidosperma leptophyllum", " Benth.", null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null, null);
         NameKey key = this.analyser.analyse(instance);
         assertTrue(condition.match(instance, key));
     }
@@ -333,7 +333,7 @@ public class MatchTaxonConditionTest extends TestUtils {
         MatchTaxonCondition condition = new MatchTaxonCondition();
         condition.setScientificNameAuthorship("Benth.");
         condition.setMatchType(NameMatchType.EXACT);
-        TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalCode.BOTANICAL, NomenclaturalCode.BOTANICAL.getAcronym(), this.provider, "Lepidosperma leptophyllum", "Bentham", null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null);
+        TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalClassifier.BOTANICAL, NomenclaturalClassifier.BOTANICAL.getAcronym(), this.provider, "Lepidosperma leptophyllum", "Bentham", null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null, null);
         NameKey key = this.analyser.analyse(instance);
         assertFalse(condition.match(instance, key));
     }
@@ -344,7 +344,7 @@ public class MatchTaxonConditionTest extends TestUtils {
         MatchTaxonCondition condition = new MatchTaxonCondition();
         condition.setScientificNameAuthorship("Benth.");
         condition.setMatchType(NameMatchType.INSENSITIVE);
-        TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalCode.BOTANICAL, NomenclaturalCode.BOTANICAL.getAcronym(), this.provider, "Lepidosperma leptophyllum", "Benth.", null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null);
+        TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalClassifier.BOTANICAL, NomenclaturalClassifier.BOTANICAL.getAcronym(), this.provider, "Lepidosperma leptophyllum", "Benth.", null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null, null);
         NameKey key = this.analyser.analyse(instance);
         assertTrue(condition.match(instance, key));
     }
@@ -354,7 +354,7 @@ public class MatchTaxonConditionTest extends TestUtils {
         MatchTaxonCondition condition = new MatchTaxonCondition();
         condition.setScientificNameAuthorship("Benth.");
         condition.setMatchType(NameMatchType.INSENSITIVE);
-        TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalCode.BOTANICAL, NomenclaturalCode.BOTANICAL.getAcronym(), this.provider, "Lepidosperma leptophyllum", " BENTh.", null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null);
+        TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalClassifier.BOTANICAL, NomenclaturalClassifier.BOTANICAL.getAcronym(), this.provider, "Lepidosperma leptophyllum", " BENTh.", null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null, null);
         NameKey key = this.analyser.analyse(instance);
         assertTrue(condition.match(instance, key));
     }
@@ -364,7 +364,7 @@ public class MatchTaxonConditionTest extends TestUtils {
         MatchTaxonCondition condition = new MatchTaxonCondition();
         condition.setScientificNameAuthorship("Benth.");
         condition.setMatchType(NameMatchType.INSENSITIVE);
-        TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalCode.BOTANICAL, NomenclaturalCode.BOTANICAL.getAcronym(), this.provider, "Lepidosperma leptophyllum", "Bentham", null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null);
+        TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalClassifier.BOTANICAL, NomenclaturalClassifier.BOTANICAL.getAcronym(), this.provider, "Lepidosperma leptophyllum", "Bentham", null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null, null);
         NameKey key = this.analyser.analyse(instance);
         assertFalse(condition.match(instance, key));
     }
@@ -374,7 +374,7 @@ public class MatchTaxonConditionTest extends TestUtils {
         MatchTaxonCondition condition = new MatchTaxonCondition();
         condition.setScientificNameAuthorship("Benth.");
         condition.setMatchType(NameMatchType.NORMALISED);
-        TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalCode.BOTANICAL, NomenclaturalCode.BOTANICAL.getAcronym(), this.provider, "Lepidosperma leptophyllum", "Benth.", null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null);
+        TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalClassifier.BOTANICAL, NomenclaturalClassifier.BOTANICAL.getAcronym(), this.provider, "Lepidosperma leptophyllum", "Benth.", null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null, null);
         NameKey key = this.analyser.analyse(instance);
         assertTrue(condition.match(instance, key));
     }
@@ -384,7 +384,7 @@ public class MatchTaxonConditionTest extends TestUtils {
         MatchTaxonCondition condition = new MatchTaxonCondition();
         condition.setScientificNameAuthorship("Benth.");
         condition.setMatchType(NameMatchType.NORMALISED);
-        TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalCode.BOTANICAL, NomenclaturalCode.BOTANICAL.getAcronym(), this.provider, "Lepidosperma leptophyllum", "Bentham", null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null);
+        TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalClassifier.BOTANICAL, NomenclaturalClassifier.BOTANICAL.getAcronym(), this.provider, "Lepidosperma leptophyllum", "Bentham", null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null, null);
         NameKey key = this.analyser.analyse(instance);
         assertTrue(condition.match(instance, key));
     }
@@ -394,7 +394,7 @@ public class MatchTaxonConditionTest extends TestUtils {
         MatchTaxonCondition condition = new MatchTaxonCondition();
         condition.setScientificNameAuthorship("Benth.");
         condition.setMatchType(NameMatchType.NORMALISED);
-        TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalCode.BOTANICAL, NomenclaturalCode.BOTANICAL.getAcronym(), this.provider, "Lepidosperma leptophyllum", "L.", null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null);
+        TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalClassifier.BOTANICAL, NomenclaturalClassifier.BOTANICAL.getAcronym(), this.provider, "Lepidosperma leptophyllum", "L.", null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null, null);
         NameKey key = this.analyser.analyse(instance);
         assertFalse(condition.match(instance, key));
     }
@@ -404,10 +404,10 @@ public class MatchTaxonConditionTest extends TestUtils {
         MatchTaxonCondition condition = new MatchTaxonCondition();
         condition.setScientificNameAuthorship("Benth\\.?");
         condition.setMatchType(NameMatchType.REGEX);
-        TaxonConceptInstance instance1 = new TaxonConceptInstance("ID-1", NomenclaturalCode.BOTANICAL, NomenclaturalCode.BOTANICAL.getAcronym(), this.provider, "Lepidosperma leptophyllum", "Benth.", null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null);
+        TaxonConceptInstance instance1 = new TaxonConceptInstance("ID-1", NomenclaturalClassifier.BOTANICAL, NomenclaturalClassifier.BOTANICAL.getAcronym(), this.provider, "Lepidosperma leptophyllum", "Benth.", null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null, null);
         NameKey key1 = this.analyser.analyse(instance1);
         assertTrue(condition.match(instance1, key1));
-        TaxonConceptInstance instance2 = new TaxonConceptInstance("ID-1", NomenclaturalCode.BOTANICAL, NomenclaturalCode.BOTANICAL.getAcronym(), this.provider, "Lepidosperma leptophyllum", "Benth", null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null);
+        TaxonConceptInstance instance2 = new TaxonConceptInstance("ID-1", NomenclaturalClassifier.BOTANICAL, NomenclaturalClassifier.BOTANICAL.getAcronym(), this.provider, "Lepidosperma leptophyllum", "Benth", null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null, null);
         NameKey key2 = this.analyser.analyse(instance2);
         assertTrue(condition.match(instance2, key2));
     }
@@ -417,13 +417,13 @@ public class MatchTaxonConditionTest extends TestUtils {
         MatchTaxonCondition condition = new MatchTaxonCondition();
         condition.setScientificNameAuthorship("[Bb]enth(am|\\.)?");
         condition.setMatchType(NameMatchType.REGEX);
-        TaxonConceptInstance instance1 = new TaxonConceptInstance("ID-1", NomenclaturalCode.BOTANICAL, NomenclaturalCode.BOTANICAL.getAcronym(), this.provider, "Lepidosperma leptophyllum", "Benth", null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null);
+        TaxonConceptInstance instance1 = new TaxonConceptInstance("ID-1", NomenclaturalClassifier.BOTANICAL, NomenclaturalClassifier.BOTANICAL.getAcronym(), this.provider, "Lepidosperma leptophyllum", "Benth", null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null, null);
         NameKey key1 = this.analyser.analyse(instance1);
         assertTrue(condition.match(instance1, key1));
-        TaxonConceptInstance instance2 = new TaxonConceptInstance("ID-1", NomenclaturalCode.BOTANICAL, NomenclaturalCode.BOTANICAL.getAcronym(), this.provider, "Lepidosperma leptophyllum", "bentham", null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null);
+        TaxonConceptInstance instance2 = new TaxonConceptInstance("ID-1", NomenclaturalClassifier.BOTANICAL, NomenclaturalClassifier.BOTANICAL.getAcronym(), this.provider, "Lepidosperma leptophyllum", "bentham", null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null, null);
         NameKey key2 = this.analyser.analyse(instance2);
         assertTrue(condition.match(instance2, key2));
-        TaxonConceptInstance instance3 = new TaxonConceptInstance("ID-1", NomenclaturalCode.BOTANICAL, NomenclaturalCode.BOTANICAL.getAcronym(), this.provider, "Lepidosperma leptophyllum", "Benth.", null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null);
+        TaxonConceptInstance instance3 = new TaxonConceptInstance("ID-1", NomenclaturalClassifier.BOTANICAL, NomenclaturalClassifier.BOTANICAL.getAcronym(), this.provider, "Lepidosperma leptophyllum", "Benth.", null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null, null);
         NameKey key3 = this.analyser.analyse(instance3);
         assertTrue(condition.match(instance3, key3));
     }
@@ -433,7 +433,7 @@ public class MatchTaxonConditionTest extends TestUtils {
         MatchTaxonCondition condition = new MatchTaxonCondition();
         condition.setScientificNameAuthorship("[Bb]enth(am|\\.)?");
         condition.setMatchType(NameMatchType.REGEX);
-        TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalCode.BOTANICAL, NomenclaturalCode.BOTANICAL.getAcronym(), this.provider, "Lepidosperma leptophyllum", "Benthos", null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null);
+        TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalClassifier.BOTANICAL, NomenclaturalClassifier.BOTANICAL.getAcronym(), this.provider, "Lepidosperma leptophyllum", "Benthos", null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null, null);
         NameKey key = this.analyser.analyse(instance);
         assertFalse(condition.match(instance, key));
     }
@@ -442,7 +442,7 @@ public class MatchTaxonConditionTest extends TestUtils {
     public void testMatch40() {
         MatchTaxonCondition condition = new MatchTaxonCondition();
         condition.setDatasetID(this.provider.getId());
-        TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalCode.BOTANICAL, NomenclaturalCode.BOTANICAL.getAcronym(), this.provider, "Lepidosperma leptophyllum", "Benth.", null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null);
+        TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalClassifier.BOTANICAL, NomenclaturalClassifier.BOTANICAL.getAcronym(), this.provider, "Lepidosperma leptophyllum", "Benth.", null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null, null);
         NameKey key = this.analyser.analyse(instance);
         assertTrue(condition.match(instance, key));
     }
@@ -451,7 +451,7 @@ public class MatchTaxonConditionTest extends TestUtils {
     public void testMatch41() {
         MatchTaxonCondition condition = new MatchTaxonCondition();
         condition.setDatasetID("other");
-        TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalCode.BOTANICAL, NomenclaturalCode.BOTANICAL.getAcronym(), this.provider, "Lepidosperma leptophyllum", "Benth.", null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null);
+        TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalClassifier.BOTANICAL, NomenclaturalClassifier.BOTANICAL.getAcronym(), this.provider, "Lepidosperma leptophyllum", "Benth.", null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null, null);
         NameKey key = this.analyser.analyse(instance);
         assertFalse(condition.match(instance, key));
     }
@@ -462,21 +462,38 @@ public class MatchTaxonConditionTest extends TestUtils {
         MatchTaxonCondition condition = new MatchTaxonCondition();
         condition.setScientificName("Unknown(\\s.*|)");
         condition.setMatchType(NameMatchType.REGEX);
-        TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalCode.BOTANICAL, NomenclaturalCode.BOTANICAL.getAcronym(), this.provider, "unknown", null, null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null);
+        TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalClassifier.BOTANICAL, NomenclaturalClassifier.BOTANICAL.getAcronym(), this.provider, "unknown", null, null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null, null);
         NameKey key = this.analyser.analyse(instance);
         assertTrue(condition.match(instance, key));
-        instance = new TaxonConceptInstance("ID-1", NomenclaturalCode.BOTANICAL, NomenclaturalCode.BOTANICAL.getAcronym(), this.provider, "Unknown sp.", null, null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null);
+        instance = new TaxonConceptInstance("ID-1", NomenclaturalClassifier.BOTANICAL, NomenclaturalClassifier.BOTANICAL.getAcronym(), this.provider, "Unknown sp.", null, null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null, null);
         key = this.analyser.analyse(instance);
         assertTrue(condition.match(instance, key));
-        instance = new TaxonConceptInstance("ID-1", NomenclaturalCode.BOTANICAL, NomenclaturalCode.BOTANICAL.getAcronym(), this.provider, "Unknownsp.", null, null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null);
+        instance = new TaxonConceptInstance("ID-1", NomenclaturalClassifier.BOTANICAL, NomenclaturalClassifier.BOTANICAL.getAcronym(), this.provider, "Unknownsp.", null, null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null, null);
         key = this.analyser.analyse(instance);
         assertFalse(condition.match(instance, key));
+    }
+
+
+
+    @Test
+    public void testMatch43() {
+        MatchTaxonCondition condition = new MatchTaxonCondition();
+        condition.setTaxonomicFlag(TaxonFlag.AMBIGUOUS_NOMENCLATURAL_CODE);
+        TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalClassifier.BOTANICAL, NomenclaturalClassifier.BOTANICAL.getAcronym(), this.provider, "unknown", null, null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null, null);
+        NameKey key = this.analyser.analyse(instance);
+        assertFalse(condition.match(instance, key));
+        instance = new TaxonConceptInstance("ID-1", NomenclaturalClassifier.BOTANICAL, NomenclaturalClassifier.BOTANICAL.getAcronym(), this.provider, "Unknown sp.", null, null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null, Collections.singleton(TaxonFlag.AUTONYM));
+        key = this.analyser.analyse(instance);
+        assertFalse(condition.match(instance, key));
+        instance = new TaxonConceptInstance("ID-1", NomenclaturalClassifier.BOTANICAL, NomenclaturalClassifier.BOTANICAL.getAcronym(), this.provider, "Unknownsp.", null, null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null, Collections.singleton(TaxonFlag.AMBIGUOUS_NOMENCLATURAL_CODE));
+        key = this.analyser.analyse(instance);
+        assertTrue(condition.match(instance, key));
     }
 
     @Test
     public void testWrite1() throws Exception {
         MatchTaxonCondition condition = new MatchTaxonCondition();
-        condition.setNomenclaturalCode(NomenclaturalCode.BOTANICAL);
+        condition.setNomenclaturalCode(NomenclaturalClassifier.BOTANICAL);
         condition.setTaxonomicStatus(TaxonomicType.EXCLUDED);
         ObjectMapper mapper = new ObjectMapper();
         mapper.enable(SerializationFeature.INDENT_OUTPUT);
@@ -489,10 +506,10 @@ public class MatchTaxonConditionTest extends TestUtils {
     public void testRead1() throws Exception {
         ObjectMapper mapper = new ObjectMapper();
         MatchTaxonCondition condition = mapper.readValue(this.resourceReader("match-condition-1.json"), MatchTaxonCondition.class);
-        TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalCode.BOTANICAL, NomenclaturalCode.BOTANICAL.getAcronym(), this.provider, "Acacia dealbata", null, null, "1975", TaxonomicType.EXCLUDED, TaxonomicType.EXCLUDED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null);
+        TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalClassifier.BOTANICAL, NomenclaturalClassifier.BOTANICAL.getAcronym(), this.provider, "Acacia dealbata", null, null, "1975", TaxonomicType.EXCLUDED, TaxonomicType.EXCLUDED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null, null);
         NameKey key = this.analyser.analyse(instance);
         assertTrue(condition.match(instance, key));
-        instance = new TaxonConceptInstance("ID-1", NomenclaturalCode.BOTANICAL, NomenclaturalCode.BOTANICAL.getAcronym(), this.provider, "Acacia dealbata", null, null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null);
+        instance = new TaxonConceptInstance("ID-1", NomenclaturalClassifier.BOTANICAL, NomenclaturalClassifier.BOTANICAL.getAcronym(), this.provider, "Acacia dealbata", null, null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null, null);
         key = this.analyser.analyse(instance);
         assertFalse(condition.match(instance, key));
     }

--- a/ala-name-matching-builder/src/test/java/au/org/ala/names/index/provider/OrTaxonConditionTest.java
+++ b/ala-name-matching-builder/src/test/java/au/org/ala/names/index/provider/OrTaxonConditionTest.java
@@ -16,15 +16,11 @@
 
 package au.org.ala.names.index.provider;
 
-import au.org.ala.names.index.ALANameAnalyser;
-import au.org.ala.names.index.NameKey;
-import au.org.ala.names.index.NameProvider;
-import au.org.ala.names.index.TaxonConceptInstance;
+import au.org.ala.names.index.*;
 import au.org.ala.names.model.TaxonomicType;
 import au.org.ala.names.util.TestUtils;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
-import org.gbif.api.vocabulary.NomenclaturalCode;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -52,9 +48,9 @@ public class OrTaxonConditionTest extends TestUtils {
     public void testMatch1() {
         OrTaxonCondition condition = new OrTaxonCondition();
         MatchTaxonCondition condition1 = new MatchTaxonCondition();
-        condition1.setNomenclaturalCode(NomenclaturalCode.BOTANICAL);
+        condition1.setNomenclaturalCode(NomenclaturalClassifier.BOTANICAL);
         condition.add(condition1);
-        TaxonConceptInstance instance = this.createInstance("ID-1", NomenclaturalCode.BOTANICAL, "Acacia dealbata", this.provider, TaxonomicType.HOMOTYPIC_SYNONYM);
+        TaxonConceptInstance instance = this.createInstance("ID-1", NomenclaturalClassifier.BOTANICAL, "Acacia dealbata", this.provider, TaxonomicType.HOMOTYPIC_SYNONYM);
         NameKey key = this.analyser.analyse(instance);
         assertTrue(condition.match(instance, key));
     }
@@ -63,9 +59,9 @@ public class OrTaxonConditionTest extends TestUtils {
     public void testMatch2() {
         OrTaxonCondition condition = new OrTaxonCondition();
         MatchTaxonCondition condition1 = new MatchTaxonCondition();
-        condition1.setNomenclaturalCode(NomenclaturalCode.ZOOLOGICAL);
+        condition1.setNomenclaturalCode(NomenclaturalClassifier.ZOOLOGICAL);
         condition.add(condition1);
-        TaxonConceptInstance instance = this.createInstance("ID-1", NomenclaturalCode.BOTANICAL, "Acacia dealbata", this.provider, TaxonomicType.HOMOTYPIC_SYNONYM);
+        TaxonConceptInstance instance = this.createInstance("ID-1", NomenclaturalClassifier.BOTANICAL, "Acacia dealbata", this.provider, TaxonomicType.HOMOTYPIC_SYNONYM);
         NameKey key = this.analyser.analyse(instance);
         assertFalse(condition.match(instance, key));
     }
@@ -75,12 +71,12 @@ public class OrTaxonConditionTest extends TestUtils {
     public void testMatch3() {
         OrTaxonCondition condition = new OrTaxonCondition();
         MatchTaxonCondition condition1 = new MatchTaxonCondition();
-        condition1.setNomenclaturalCode(NomenclaturalCode.BOTANICAL);
+        condition1.setNomenclaturalCode(NomenclaturalClassifier.BOTANICAL);
         MatchTaxonCondition condition2 = new MatchTaxonCondition();
         condition2.setTaxonomicStatus(TaxonomicType.HOMOTYPIC_SYNONYM);
         condition.add(condition1);
         condition.add(condition2);
-        TaxonConceptInstance instance = this.createInstance("ID-1", NomenclaturalCode.BOTANICAL, "Acacia dealbata", this.provider, TaxonomicType.HOMOTYPIC_SYNONYM);
+        TaxonConceptInstance instance = this.createInstance("ID-1", NomenclaturalClassifier.BOTANICAL, "Acacia dealbata", this.provider, TaxonomicType.HOMOTYPIC_SYNONYM);
         NameKey key = this.analyser.analyse(instance);
         assertTrue(condition.match(instance, key));
     }
@@ -89,12 +85,12 @@ public class OrTaxonConditionTest extends TestUtils {
     public void testMatch4() {
         OrTaxonCondition condition = new OrTaxonCondition();
         MatchTaxonCondition condition1 = new MatchTaxonCondition();
-        condition1.setNomenclaturalCode(NomenclaturalCode.BOTANICAL);
+        condition1.setNomenclaturalCode(NomenclaturalClassifier.BOTANICAL);
         MatchTaxonCondition condition2 = new MatchTaxonCondition();
         condition2.setTaxonomicStatus(TaxonomicType.HOMOTYPIC_SYNONYM);
         condition.add(condition1);
         condition.add(condition2);
-        TaxonConceptInstance instance = this.createInstance("ID-1", NomenclaturalCode.ZOOLOGICAL, "Acacia dealbata", this.provider, TaxonomicType.HOMOTYPIC_SYNONYM);
+        TaxonConceptInstance instance = this.createInstance("ID-1", NomenclaturalClassifier.ZOOLOGICAL, "Acacia dealbata", this.provider, TaxonomicType.HOMOTYPIC_SYNONYM);
         NameKey key = this.analyser.analyse(instance);
         assertTrue(condition.match(instance, key));
     }
@@ -103,12 +99,12 @@ public class OrTaxonConditionTest extends TestUtils {
     public void testMatch5() {
         OrTaxonCondition condition = new OrTaxonCondition();
         MatchTaxonCondition condition1 = new MatchTaxonCondition();
-        condition1.setNomenclaturalCode(NomenclaturalCode.BOTANICAL);
+        condition1.setNomenclaturalCode(NomenclaturalClassifier.BOTANICAL);
         MatchTaxonCondition condition2 = new MatchTaxonCondition();
         condition2.setTaxonomicStatus(TaxonomicType.HOMOTYPIC_SYNONYM);
         condition.add(condition1);
         condition.add(condition2);
-        TaxonConceptInstance instance = this.createInstance("ID-1", NomenclaturalCode.BOTANICAL, "Acacia dealbata", this.provider, TaxonomicType.ACCEPTED);
+        TaxonConceptInstance instance = this.createInstance("ID-1", NomenclaturalClassifier.BOTANICAL, "Acacia dealbata", this.provider, TaxonomicType.ACCEPTED);
         NameKey key = this.analyser.analyse(instance);
         assertTrue(condition.match(instance, key));
     }
@@ -117,12 +113,12 @@ public class OrTaxonConditionTest extends TestUtils {
     public void testMatch6() {
         OrTaxonCondition condition = new OrTaxonCondition();
         MatchTaxonCondition condition1 = new MatchTaxonCondition();
-        condition1.setNomenclaturalCode(NomenclaturalCode.BOTANICAL);
+        condition1.setNomenclaturalCode(NomenclaturalClassifier.BOTANICAL);
         MatchTaxonCondition condition2 = new MatchTaxonCondition();
         condition2.setTaxonomicStatus(TaxonomicType.HOMOTYPIC_SYNONYM);
         condition.add(condition1);
         condition.add(condition2);
-        TaxonConceptInstance instance = this.createInstance("ID-1", NomenclaturalCode.ZOOLOGICAL, "Acacia dealbata", this.provider, TaxonomicType.ACCEPTED);
+        TaxonConceptInstance instance = this.createInstance("ID-1", NomenclaturalClassifier.ZOOLOGICAL, "Acacia dealbata", this.provider, TaxonomicType.ACCEPTED);
         NameKey key = this.analyser.analyse(instance);
         assertFalse(condition.match(instance, key));
     }
@@ -131,7 +127,7 @@ public class OrTaxonConditionTest extends TestUtils {
     public void testWrite1() throws Exception {
         OrTaxonCondition condition = new OrTaxonCondition();
         MatchTaxonCondition condition1 = new MatchTaxonCondition();
-        condition1.setNomenclaturalCode(NomenclaturalCode.BOTANICAL);
+        condition1.setNomenclaturalCode(NomenclaturalClassifier.BOTANICAL);
         MatchTaxonCondition condition2 = new MatchTaxonCondition();
         condition2.setTaxonomicStatus(TaxonomicType.HOMOTYPIC_SYNONYM);
         condition.add(condition1);
@@ -147,13 +143,13 @@ public class OrTaxonConditionTest extends TestUtils {
     public void testRead1() throws Exception {
         ObjectMapper mapper = new ObjectMapper();
         OrTaxonCondition condition = mapper.readValue(this.resourceReader("or-condition-1.json"), OrTaxonCondition.class);
-        TaxonConceptInstance instance = this.createInstance("ID-1", NomenclaturalCode.BOTANICAL, "Acacia dealbata", this.provider, TaxonomicType.HOMOTYPIC_SYNONYM);
+        TaxonConceptInstance instance = this.createInstance("ID-1", NomenclaturalClassifier.BOTANICAL, "Acacia dealbata", this.provider, TaxonomicType.HOMOTYPIC_SYNONYM);
         NameKey key = this.analyser.analyse(instance);
         assertTrue(condition.match(instance, key));
-        instance = this.createInstance("ID-1", NomenclaturalCode.BOTANICAL, "Acacia dealbata", this.provider, TaxonomicType.ACCEPTED);
+        instance = this.createInstance("ID-1", NomenclaturalClassifier.BOTANICAL, "Acacia dealbata", this.provider, TaxonomicType.ACCEPTED);
         key = this.analyser.analyse(instance);
         assertTrue(condition.match(instance, key));
-        instance = this.createInstance("ID-1", NomenclaturalCode.ZOOLOGICAL, "Acacia dealbata", this.provider, TaxonomicType.ACCEPTED);
+        instance = this.createInstance("ID-1", NomenclaturalClassifier.ZOOLOGICAL, "Acacia dealbata", this.provider, TaxonomicType.ACCEPTED);
         key = this.analyser.analyse(instance);
         assertFalse(condition.match(instance, key));
     }

--- a/ala-name-matching-builder/src/test/java/au/org/ala/names/index/provider/ScoreAdjusterTest.java
+++ b/ala-name-matching-builder/src/test/java/au/org/ala/names/index/provider/ScoreAdjusterTest.java
@@ -16,14 +16,10 @@
 
 package au.org.ala.names.index.provider;
 
-import au.org.ala.names.index.ALANameAnalyser;
-import au.org.ala.names.index.NameKey;
-import au.org.ala.names.index.NameProvider;
-import au.org.ala.names.index.TaxonConceptInstance;
+import au.org.ala.names.index.*;
 import au.org.ala.names.model.RankType;
 import au.org.ala.names.model.TaxonomicType;
 import au.org.ala.names.util.TestUtils;
-import org.gbif.api.vocabulary.NomenclaturalCode;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -59,7 +55,7 @@ public class ScoreAdjusterTest extends TestUtils {
 
     @Test
     public void testForbidden1() {
-        TaxonConceptInstance instance = this.createInstance("ID-1", NomenclaturalCode.ZOOLOGICAL, "Osphranter rufus", this.provider, TaxonomicType.ACCEPTED );
+        TaxonConceptInstance instance = this.createInstance("ID-1", NomenclaturalClassifier.ZOOLOGICAL, "Osphranter rufus", this.provider, TaxonomicType.ACCEPTED );
         NameKey key = this.analyser.analyse(instance);
         assertNull(adjuster.forbid(instance, key));
     }
@@ -67,49 +63,49 @@ public class ScoreAdjusterTest extends TestUtils {
 
     @Test
     public void testForbidden2() {
-        TaxonConceptInstance instance = this.createInstance("ID-1", NomenclaturalCode.ZOOLOGICAL, "Osphranter rufus", this.provider, TaxonomicType.INCERTAE_SEDIS );
+        TaxonConceptInstance instance = this.createInstance("ID-1", NomenclaturalClassifier.ZOOLOGICAL, "Osphranter rufus", this.provider, TaxonomicType.INCERTAE_SEDIS );
         NameKey key = this.analyser.analyse(instance);
         assertEquals("taxonomicStatus:INCERTAE_SEDIS", adjuster.forbid(instance, key));
     }
 
     @Test
     public void testScore1() {
-        TaxonConceptInstance instance = this.createInstance("ID-1", NomenclaturalCode.ZOOLOGICAL, "Osphranter rufus", this.provider, TaxonomicType.ACCEPTED );
+        TaxonConceptInstance instance = this.createInstance("ID-1", NomenclaturalClassifier.ZOOLOGICAL, "Osphranter rufus", this.provider, TaxonomicType.ACCEPTED );
         NameKey key = this.analyser.analyse(instance);
         assertEquals(0, adjuster.score(0, instance, key));
     }
 
     @Test
     public void testScore2() {
-        TaxonConceptInstance instance = this.createInstance("ID-1", NomenclaturalCode.ZOOLOGICAL, "Osphranter rufus", this.provider, TaxonomicType.ACCEPTED );
+        TaxonConceptInstance instance = this.createInstance("ID-1", NomenclaturalClassifier.ZOOLOGICAL, "Osphranter rufus", this.provider, TaxonomicType.ACCEPTED );
         NameKey key = this.analyser.analyse(instance);
         assertEquals(50, adjuster.score(50, instance, key));
     }
 
     @Test
     public void testScore3() {
-        TaxonConceptInstance instance = this.createInstance("ID-1", NomenclaturalCode.ZOOLOGICAL, "Osphranter rufus", this.provider, TaxonomicType.MISAPPLIED );
+        TaxonConceptInstance instance = this.createInstance("ID-1", NomenclaturalClassifier.ZOOLOGICAL, "Osphranter rufus", this.provider, TaxonomicType.MISAPPLIED );
         NameKey key = this.analyser.analyse(instance);
         assertEquals(-10, adjuster.score(0, instance, key));
     }
 
     @Test
     public void testScore4() {
-        TaxonConceptInstance instance = this.createInstance("ID-1", NomenclaturalCode.ZOOLOGICAL, "Osphranter rufus", this.provider, TaxonomicType.MISAPPLIED );
+        TaxonConceptInstance instance = this.createInstance("ID-1", NomenclaturalClassifier.ZOOLOGICAL, "Osphranter rufus", this.provider, TaxonomicType.MISAPPLIED );
         NameKey key = this.analyser.analyse(instance);
         assertEquals(90, adjuster.score(100, instance, key));
     }
 
     @Test
     public void testScore5() {
-        TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalCode.BOTANICAL, NomenclaturalCode.BOTANICAL.getAcronym(), this.provider,"Acacia dealbata", "Link.", null, null, TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.DOMAIN,  RankType.DOMAIN.getRank(), null, null,null, null, null, null, null, null, null, null);
+        TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalClassifier.BOTANICAL, NomenclaturalClassifier.BOTANICAL.getAcronym(), this.provider,"Acacia dealbata", "Link.", null, null, TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.DOMAIN,  RankType.DOMAIN.getRank(), null, null,null, null, null, null, null, null, null, null, null);
         NameKey key = this.analyser.analyse(instance);
         assertEquals(115, adjuster.score(100, instance, key));
     }
 
     @Test
     public void testScore6() {
-        TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalCode.BOTANICAL, NomenclaturalCode.BOTANICAL.getAcronym(), this.provider,"Acacia dealbata", "Link.", null, null, TaxonomicType.MISAPPLIED, TaxonomicType.MISAPPLIED.getTerm(), RankType.DOMAIN,  RankType.DOMAIN.getRank(), null, null,null, null, null, null, null, null, null, null);
+        TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalClassifier.BOTANICAL, NomenclaturalClassifier.BOTANICAL.getAcronym(), this.provider,"Acacia dealbata", "Link.", null, null, TaxonomicType.MISAPPLIED, TaxonomicType.MISAPPLIED.getTerm(), RankType.DOMAIN,  RankType.DOMAIN.getRank(), null, null,null, null, null, null, null, null, null, null, null);
         NameKey key = this.analyser.analyse(instance);
         assertEquals(105, adjuster.score(100, instance, key));
     }

--- a/ala-name-matching-builder/src/test/java/au/org/ala/names/util/TestUtils.java
+++ b/ala-name-matching-builder/src/test/java/au/org/ala/names/util/TestUtils.java
@@ -17,12 +17,11 @@
 package au.org.ala.names.util;
 
 import au.org.ala.names.index.NameProvider;
+import au.org.ala.names.index.NomenclaturalClassifier;
 import au.org.ala.names.index.TaxonConceptInstance;
 import au.org.ala.names.model.RankType;
 import au.org.ala.names.model.TaxonomicType;
 import org.apache.commons.io.IOUtils;
-import org.gbif.api.vocabulary.NomenclaturalCode;
-import org.gbif.api.vocabulary.Rank;
 
 import java.io.*;
 import java.util.regex.Pattern;
@@ -58,12 +57,12 @@ public class TestUtils {
         return new InputStreamReader(is, "UTF-8");
     }
 
-    public TaxonConceptInstance createInstance(String id, NomenclaturalCode code, String name, NameProvider provider) {
-        return new TaxonConceptInstance(id, code, code.getAcronym(), provider, name, null, null, null, TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null,null, null, null, null, null, null, null, null);
+    public TaxonConceptInstance createInstance(String id, NomenclaturalClassifier code, String name, NameProvider provider) {
+        return new TaxonConceptInstance(id, code, code.getAcronym(), provider, name, null, null, null, TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null,null, null, null, null, null, null, null, null, null);
     }
 
-    public TaxonConceptInstance createInstance(String id, NomenclaturalCode code, String name, NameProvider provider, TaxonomicType taxonomicStatus) {
-        return new TaxonConceptInstance(id, code, code.getAcronym(), provider, name, null, null, null, taxonomicStatus, taxonomicStatus.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null);
+    public TaxonConceptInstance createInstance(String id, NomenclaturalClassifier code, String name, NameProvider provider, TaxonomicType taxonomicStatus) {
+        return new TaxonConceptInstance(id, code, code.getAcronym(), provider, name, null, null, null, taxonomicStatus, taxonomicStatus.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null, null);
     }
 
     public int rowCount(File file) throws IOException {

--- a/ala-name-matching-builder/src/test/resources/au/org/ala/names/index/name-provider-1.json
+++ b/ala-name-matching-builder/src/test/resources/au/org/ala/names/index/name-provider-1.json
@@ -43,7 +43,7 @@
         {
           "condition": {
             "@class": "au.org.ala.names.index.provider.MatchTaxonCondition",
-            "nomenclaturalCode": "BOTANICAL"
+            "nomenclaturalCode": "ICBN"
           },
           "adjustment": 10
         }

--- a/ala-name-matching-builder/src/test/resources/au/org/ala/names/index/provider/and-condition-1.json
+++ b/ala-name-matching-builder/src/test/resources/au/org/ala/names/index/provider/and-condition-1.json
@@ -2,7 +2,7 @@
   "@class" : "au.org.ala.names.index.provider.AndTaxonCondition",
   "and" : [ {
     "@class" : "au.org.ala.names.index.provider.MatchTaxonCondition",
-    "nomenclaturalCode" : "BOTANICAL"
+    "nomenclaturalCode" : "ICBN"
   }, {
     "@class" : "au.org.ala.names.index.provider.MatchTaxonCondition",
     "taxonomicStatus" : "HOMOTYPIC_SYNONYM"

--- a/ala-name-matching-builder/src/test/resources/au/org/ala/names/index/provider/match-condition-1.json
+++ b/ala-name-matching-builder/src/test/resources/au/org/ala/names/index/provider/match-condition-1.json
@@ -1,5 +1,5 @@
 {
   "@class" : "au.org.ala.names.index.provider.MatchTaxonCondition",
-  "nomenclaturalCode" : "BOTANICAL",
+  "nomenclaturalCode" : "ICBN",
   "taxonomicStatus" : "EXCLUDED"
 }

--- a/ala-name-matching-builder/src/test/resources/au/org/ala/names/index/provider/or-condition-1.json
+++ b/ala-name-matching-builder/src/test/resources/au/org/ala/names/index/provider/or-condition-1.json
@@ -2,7 +2,7 @@
   "@class" : "au.org.ala.names.index.provider.OrTaxonCondition",
   "any" : [ {
     "@class" : "au.org.ala.names.index.provider.MatchTaxonCondition",
-    "nomenclaturalCode" : "BOTANICAL"
+    "nomenclaturalCode" : "ICBN"
   }, {
     "@class" : "au.org.ala.names.index.provider.MatchTaxonCondition",
     "taxonomicStatus" : "HOMOTYPIC_SYNONYM"

--- a/ala-name-matching-builder/src/test/resources/au/org/ala/names/index/taxonomy-33.csv
+++ b/ala-name-matching-builder/src/test/resources/au/org/ala/names/index/taxonomy-33.csv
@@ -1,0 +1,3 @@
+taxonID,parentNameUsageID,acceptedNameUsageID,datasetID,nomenclaturalCode,scientificName,scientificNameAuthorship,taxonRank,taxonConceptID,scientificNameID,taxonomicStatus,nomenclaturalStatus,establishmentMeans,nameAccordingToID,nameAccordingTo,namePublishedInID,namePublishedIn,namePubishedInYear,nameComplete,nameFormatted,source,taxonomicFlags
+"Concept-1-1","","","dr117","ICBN","Eugregarinorida",,"order","","","accepted","","","","","","","","","","","ambiguousNomenclaturalCode"
+"Concept-1-2","","","dr118","ICZN","EUGREGARINORIDA","Leger, 1900","order","","","accepted","","","","","","","","","","","ambiguousNomenclaturalCode"

--- a/ala-name-matching-builder/src/test/resources/au/org/ala/names/index/taxonomy-config-2.json
+++ b/ala-name-matching-builder/src/test/resources/au/org/ala/names/index/taxonomy-config-2.json
@@ -32,6 +32,13 @@
             "scientificName" : "Viruses"
           },
           "scientificName": "VIRUS"
+        },
+        {
+          "condition": {
+            "@class" : "au.org.ala.names.index.provider.MatchTaxonCondition",
+            "taxonomicFlag" : "AMBIGUOUS_NOMENCLATURAL_CODE"
+          },
+          "nomenclaturalCode": "EUK"
         }
       ]
     }
@@ -139,6 +146,26 @@
     "parent": "dr114",
     "authority": false,
     "defaultScore": 100
+  },{
+    "id" : "dr117",
+    "parent": "dr114",
+    "defaultScore": 100,
+    "keyAdjuster": {
+      "adjustments": [
+        {
+          "condition": {
+            "@class" : "au.org.ala.names.index.provider.MatchTaxonCondition",
+            "taxonomicFlag" : "AMBIGUOUS_NOMENCLATURAL_CODE"
+          },
+          "nomenclaturalCode": "EUK"
+        }
+      ]
+    }
+  },{
+    "id" : "dr118",
+    "parent": "dr117",
+    "authority": false,
+    "defaultScore": 200
   }
   ],
   "defaultProvider" : "unknown",

--- a/ala-name-matching-model/src/main/java/au/org/ala/names/model/TaxonFlag.java
+++ b/ala-name-matching-model/src/main/java/au/org/ala/names/model/TaxonFlag.java
@@ -17,12 +17,14 @@
 package au.org.ala.names.model;
 
 /**
- * Flags indicating special-case information about a name
+ * Flags indicating special-case information about a taxon
  *
  * @author Doug Palmer &lt;Doug.Palmer@csiro.au&gt;
  * @copyright Copyright &copy; 2019 Atlas of Living Australia
  */
-public enum NameFlag {
+public enum TaxonFlag {
     /** The name is an autonymn, meaning that it has been created without an author because a sub-taxon was created */
-    AUTONYM
+    AUTONYM,
+    /** The nomenclatural code used by various sources is variable. This often occurs with different classifications of Chromista, Protista, etc. */
+    AMBIGUOUS_NOMENCLATURAL_CODE
 }

--- a/ala-name-matching-model/src/main/java/au/org/ala/vocab/ALATerm.java
+++ b/ala-name-matching-model/src/main/java/au/org/ala/vocab/ALATerm.java
@@ -72,7 +72,9 @@ public enum ALATerm implements Term {
     /** The principal taxon identifier, for taxa that may have been re-assigned */
     principalTaxonID,
     /** The principal scientific name, for taxa that may have been re-assigned */
-    principalScientificNBame,
+    principalScientificName,
+    /** Any taxonomic flags */
+    taxonomicFlags,
     /** Record type describing an unplaced vernacular name */
     UnplacedVernacularName,
     /** Record type describing a variant (different source, spelling etc.) of a taxon */

--- a/ala-name-matching-search/src/test/java/au/org/ala/names/search/ALANameSearcherTest.java
+++ b/ala-name-matching-search/src/test/java/au/org/ala/names/search/ALANameSearcherTest.java
@@ -36,7 +36,7 @@ public class ALANameSearcherTest {
 
     @org.junit.BeforeClass
     public static void init() throws Exception {
-        searcher = new ALANameSearcher("/data/lucene/namematching-20210811");
+        searcher = new ALANameSearcher("/data/lucene/namematching-20210811-2");
     }
 
     @Test

--- a/ala-name-matching-search/src/test/java/au/org/ala/names/search/AutocompleteTest.java
+++ b/ala-name-matching-search/src/test/java/au/org/ala/names/search/AutocompleteTest.java
@@ -32,7 +32,7 @@ public class AutocompleteTest {
 
     @org.junit.BeforeClass
     public static void init() throws Exception {
-        searcher = new ALANameSearcher("/data/lucene/namematching-20210811");
+        searcher = new ALANameSearcher("/data/lucene/namematching-20210811-2");
     }
 
     @Test
@@ -52,10 +52,10 @@ public class AutocompleteTest {
         Map first = results.get(0);
         assertEquals("Samadera sp. Mary River", first.get("name"));
         Map second = results.get(1);
-        assertEquals("Mary River cod", second.get("commonname"));
+        assertEquals("Mary River Cod", second.get("commonname"));
         assertEquals("Maccullochella mariensis", second.get("name"));
         Map third = results.get(2);
-        assertEquals("Mary River turtle", third.get("commonname"));
+        assertEquals("Mary River Turtle", third.get("commonname"));
         assertEquals("Elusor macrurus", third.get("name"));
     }
 
@@ -65,7 +65,7 @@ public class AutocompleteTest {
         assertNotNull(results);
         assertTrue(results.size() > 0);
         Map first = results.get(0);
-        assertEquals("Mary River turtle", first.get("commonname"));
+        assertEquals("Mary River Turtle", first.get("commonname"));
         assertEquals("Elusor macrurus", first.get("name"));
     }
 
@@ -130,7 +130,7 @@ public class AutocompleteTest {
         assertNotNull(results);
         assertTrue(results.size() > 0);
         Map first = results.get(0);
-        assertEquals("Rhachotropis rossi", first.get("name"));
+        assertEquals("Pleurotomella rossi", first.get("name"));
     }
 
 
@@ -147,16 +147,16 @@ public class AutocompleteTest {
 
     @Test
     public void testAutocomplete12() throws Exception {
-        List<Map> results = searcher.autocomplete("rush", 10, true);
+        List<Map> results = searcher.autocomplete("rush li", 10, true);
         assertNotNull(results);
-        assertTrue(results.size() > 0);
-        Map first = results.get(0);
-        assertEquals("Acacia alleniana", first.get("name"));
-        List<Map> synonyms = (List<Map>) first.get("synonymMatch");
+        assertTrue(results.size() > 2);
+        Map syn = results.get(2);
+        assertEquals("Sisyrinchium rosulatum", syn.get("name"));
+        List<Map> synonyms = (List<Map>) syn.get("synonymMatch");
         assertNotNull(synonyms);
         assertTrue(synonyms.size() > 0);
         Map synonym = synonyms.get(0);
-        assertEquals("Rush-leaved Wattle", synonym.get("commonname"));
+        assertEquals("Yellow Rush Lily", synonym.get("commonname"));
     }
 
 }

--- a/ala-name-matching-search/src/test/java/au/org/ala/names/search/BiocacheMatchTest.java
+++ b/ala-name-matching-search/src/test/java/au/org/ala/names/search/BiocacheMatchTest.java
@@ -38,7 +38,7 @@ public class BiocacheMatchTest {
 
     @org.junit.BeforeClass
     public static void init() throws Exception {
-        searcher = new ALANameSearcher("/data/lucene/namematching-20210811");
+        searcher = new ALANameSearcher("/data/lucene/namematching-20210811-2");
     }
 
     @Test

--- a/ala-name-matching-search/src/test/java/au/org/ala/names/search/IconicSpeciesTest.java
+++ b/ala-name-matching-search/src/test/java/au/org/ala/names/search/IconicSpeciesTest.java
@@ -47,7 +47,7 @@ public class IconicSpeciesTest {
 
     @org.junit.BeforeClass
     public static void init() throws Exception {
-        searcher = new ALANameSearcher("/data/lucene/namematching-20210811");
+        searcher = new ALANameSearcher("/data/lucene/namematching-20210811-2");
     }
 
     //@Test

--- a/ala-name-matching-search/src/test/java/au/org/ala/names/search/VernacularMatchTest.java
+++ b/ala-name-matching-search/src/test/java/au/org/ala/names/search/VernacularMatchTest.java
@@ -40,7 +40,7 @@ public class VernacularMatchTest {
 
     @org.junit.BeforeClass
     public static void init() throws Exception {
-        searcher = new ALANameSearcher("/data/lucene/namematching-20210811");
+        searcher = new ALANameSearcher("/data/lucene/namematching-20210811-2");
      }
 
     @Test

--- a/data/ala-taxon-config.json
+++ b/data/ala-taxon-config.json
@@ -615,6 +615,13 @@
               "taxonRank": "CULTIVARGROUP"
             },
             "rank": "CULTIVAR"
+          },
+          {
+            "condition": {
+              "@class" : "au.org.ala.names.index.provider.MatchTaxonCondition",
+              "taxonomicFlag": "AMBIGUOUS_NOMENCLATURAL_CODE"
+            },
+            "nomenclaturalCode": "EUK"
           }
         ]
       },
@@ -623,6 +630,7 @@
         "Aega monophthalam": "Aega monophthalma",
         "Aegaeon rathbunae": "Aegaeon rathbuni",
         "Albugo trianthemae": "Albugo trianthemi",
+        "Amphiura triscacantha": "Amphiura trisacantha",
         "Aquilonastra bryneae": "Aquilonastra byrneae",
         "Armandia filibranhcia": "Armandia filibranchia",
         "Arthonia anjutiae": "Arthonia anjutii",


### PR DESCRIPTION
See https://github.com/AtlasOfLivingAustralia/ala-name-matching/issues/138

Replace GBIF nomenclatural codes enum with a more SKOS-y vocabulary. This allows certain kingdoms to share a code while merging.

