### PR TITLE
Import identifiers from DwCA

### DIFF
--- a/ala-name-matching-builder/src/main/java/au/org/ala/names/index/ALANameAnalyser.java
+++ b/ala-name-matching-builder/src/main/java/au/org/ala/names/index/ALANameAnalyser.java
@@ -82,17 +82,23 @@ public class ALANameAnalyser extends NameAnalyser {
      */
     protected static final Pattern BRACKETED = Pattern.compile("\\s(\\[.+\\]|\\{.+\\})");
 
+    /**
+     * Detect a rank name where a nomrmal name should go
+     */
+    private static final String RANK_NAMES = Arrays.stream(Rank.values()).map(Rank::name).collect(Collectors.joining("|"));
+    private static final Pattern RANK_AS_NAME = Pattern.compile("(?i:" + RANK_NAMES + ")");
 
-    private static final String RANK_MARKERS = Arrays.stream(Rank.values()).filter(r -> r.getMarker() != null).map(r -> r.getMarker().replaceAll("\\.", "")).collect(Collectors.joining("|"));
-    private static final String RANK_PLACEHOLDER_MARKERS = "\\p{Alpha}";
+    private static final String RANK_MARKERS_STRICT = Arrays.stream(Rank.values()).filter(r -> r.getMarker() != null).map(r -> r.getMarker().replaceAll("\\.", "\\.")).collect(Collectors.joining("|"));
+    private static final String RANK_MARKERS_LOOSE = Arrays.stream(Rank.values()).filter(r -> r.getMarker() != null).map(r -> r.getMarker().replaceAll("\\.", "\\.?")).collect(Collectors.joining("|"));
+    private static final String RANK_PLACEHOLDER_MARKERS = "\\p{Alpha}\\.";
     /**
      * Pattern for rank markers
      */
-    protected static final Pattern STRICT_MARKERS = Pattern.compile("\\s+(?:" + RANK_MARKERS + "|" + RANK_PLACEHOLDER_MARKERS + ")\\.\\s+");
+    protected static final Pattern STRICT_MARKERS = Pattern.compile("\\s+(?:" + RANK_MARKERS_STRICT + "|" + RANK_PLACEHOLDER_MARKERS + ")\\s+");
     /**
      * Pattern for bare (no proper period) rank markers
      */
-    protected static final Pattern LOOSE_MARKERS = Pattern.compile("\\s+(?:" + RANK_MARKERS + "|" + RANK_PLACEHOLDER_MARKERS + ")\\.?\\s+");
+    protected static final Pattern LOOSE_MARKERS = Pattern.compile("\\s+(?:" + RANK_MARKERS_LOOSE + "|" + RANK_PLACEHOLDER_MARKERS + ")\\.?\\s+");
     /**
      * Pattern for unsure markers (cf, aff etc)
      */
@@ -133,11 +139,11 @@ public class ALANameAnalyser extends NameAnalyser {
      */
     protected static final Pattern DOUBTFUL = Pattern.compile("((^| )(undet|indet|aff|cf)[#!?\\.]?)+(?![a-z])");
 
-
     /**
      * Something that looks like an unplaced name
      */
     protected static final Predicate<String> PLACEHOLDER_TEST = Pattern.compile("(?i:species inquirenda|incertae sedis|unplaced)").asPredicate();
+
     /**
      * Something that looks like a hybrid
      */
@@ -227,7 +233,7 @@ public class ALANameAnalyser extends NameAnalyser {
                     rankType = RankType.getForCBRank(name.getRank());
             }
         } catch (UnparsableException ex) {
-            // Oh well, worth a try
+            LOGGER.info("Unable to parse " + name + ": " + ex.getMessage());
         }
         if (UNSURE_MARKER.matcher(scientificName).find()) {
             // Leave this well alone but indicate that it is doubtful
@@ -252,7 +258,9 @@ public class ALANameAnalyser extends NameAnalyser {
 
 
         // Categorize
-        if (PLACEHOLDER_TEST.test(scientificName) || (taxonomicStatus != null && taxonomicStatus.isPlaceholder())) {
+        if (taxonomicStatus == TaxonomicType.MISCELLANEOUS_LITERATURE) {
+            nameType = NameType.INFORMAL;
+        } else if (PLACEHOLDER_TEST.test(scientificName) || (taxonomicStatus != null && taxonomicStatus.isPlaceholder())) {
             scientificName = scientificName + " " + UUID.randomUUID().toString();
             nameType = NameType.PLACEHOLDER;
         } else if (code == NomenclaturalClassifier.VIRUS) {
@@ -300,18 +308,24 @@ public class ALANameAnalyser extends NameAnalyser {
 
 
         NameKey key = new NameKey(this, code, scientificName, scientificNameAuthorship, rankType, nameType, flags);
-        if (name == null)
-            return new AnalysisResult(key, null, null, null, null, null);
-        else
-            return new AnalysisResult(
-                    key,
-                    name.getGenusOrAbove(),
-                    rankType != null && !rankType.isHigherThan(RankType.GENUS) ? name.getGenusOrAbove() : null,
-                    name.getSpecificEpithet(),
-                    name.getInfraSpecificEpithet(),
-                    name.getCultivarEpithet()
-            );
-    }
+        String mononomial = null;
+        String genus = null;
+        String specificEpithet = null;
+        String infraspecificEpithet = null;
+        String cultivarEpithet = null;
+        if (name != null) {
+            mononomial = name.getGenusOrAbove();
+            if (mononomial != null && RANK_AS_NAME.matcher(mononomial).matches()) {
+                mononomial = null;
+            } else {
+                genus = rankType != null && !rankType.isHigherThan(RankType.GENUS) ? mononomial : null;
+                specificEpithet = name.getSpecificEpithet();
+                infraspecificEpithet = name.getInfraSpecificEpithet();
+                cultivarEpithet = name.getCultivarEpithet();
+            }
+        }
+        return new AnalysisResult(key, mononomial, genus, specificEpithet, infraspecificEpithet, cultivarEpithet);
+     }
 
     /**
      * Load a set of additional terms for a controlled vocabulary.

--- a/ala-name-matching-builder/src/main/java/au/org/ala/names/index/NameAnalyser.java
+++ b/ala-name-matching-builder/src/main/java/au/org/ala/names/index/NameAnalyser.java
@@ -63,14 +63,14 @@ abstract public class NameAnalyser implements Comparator<NameKey>, Reporter {
     /**
      * Convienience method for testing.
      */
-    public NameKey analyse(TaxonConceptInstance instance) {
+    public AnalysisResult analyse(TaxonConceptInstance instance) {
         return this.analyse(instance.getCode(), instance.getScientificName(), instance.getScientificNameAuthorship(), instance.getRank(), instance.getTaxonomicStatus(), instance.getFlags(), false);
     }
 
     /**
      * Convienience method for testing.
      */
-    public NameKey analyse(String code, String scientificName, String scientificNameAuthorship, String rank) {
+    public AnalysisResult analyse(String code, String scientificName, String scientificNameAuthorship, String rank) {
         NomenclaturalClassifier canonicalCode = this.canonicaliseCode(code);
         RankType rankType = this.canonicaliseRank(rank);
         return this.analyse(canonicalCode, scientificName, scientificNameAuthorship, rankType, null, null, false);
@@ -92,7 +92,7 @@ abstract public class NameAnalyser implements Comparator<NameKey>, Reporter {
      *
      * @return A suitable name key
      */
-    abstract public NameKey analyse(@Nullable NomenclaturalClassifier code, String scientificName, @Nullable String scientificNameAuthorship, @Nullable RankType rankType, @Nullable TaxonomicType taxonomicStatus, @Nullable Set<TaxonFlag> flags, boolean loose);
+    abstract public AnalysisResult analyse(@Nullable NomenclaturalClassifier code, String scientificName, @Nullable String scientificNameAuthorship, @Nullable RankType rankType, @Nullable TaxonomicType taxonomicStatus, @Nullable Set<TaxonFlag> flags, boolean loose);
 
     /**
      * Set the issue reporter.
@@ -247,5 +247,63 @@ abstract public class NameAnalyser implements Comparator<NameKey>, Reporter {
             this.reporter.report(type, code, main, associated);
         else
             logger.warn("Report " + type.name() + " code=" + code + " main=" + main.toString() + " associated=" + associated);
+    }
+
+    /**
+     * The result of a name analysis.
+     * <p>
+     * As well as the all-important name key, any fragments of information about the parsed name are also returned.
+     * </p>
+     */
+    public static class AnalysisResult {
+        private NameKey nameKey;
+        @Nullable
+        private String mononomial;
+        @Nullable
+        private String genus;
+        @Nullable
+        private String specificEpithet;
+        @Nullable
+        private String infraspecificEpithet;
+        @Nullable
+        private String cultivarEpithet;
+
+        public AnalysisResult(NameKey nameKey, @Nullable String mononomial, @Nullable String genus, @Nullable String specificEpithet, @Nullable String infraspecificEpithet, @Nullable String cultivarEpithet) {
+            this.nameKey = nameKey;
+            this.mononomial = mononomial;
+            this.genus = genus;
+            this.specificEpithet = specificEpithet;
+            this.infraspecificEpithet = infraspecificEpithet;
+            this.cultivarEpithet = cultivarEpithet;
+        }
+
+        public NameKey getNameKey() {
+            return this.nameKey;
+        }
+
+        @Nullable
+        public String getMononomial() {
+            return this.mononomial;
+        }
+
+        @Nullable
+        public String getGenus() {
+            return this.genus;
+        }
+
+        @Nullable
+        public String getSpecificEpithet() {
+            return this.specificEpithet;
+        }
+
+        @Nullable
+        public String getInfraspecificEpithet() {
+            return this.infraspecificEpithet;
+        }
+
+        @Nullable
+        public String getCultivarEpithet() {
+            return this.cultivarEpithet;
+        }
     }
 }

--- a/ala-name-matching-builder/src/main/java/au/org/ala/names/index/TaxonConceptInstance.java
+++ b/ala-name-matching-builder/src/main/java/au/org/ala/names/index/TaxonConceptInstance.java
@@ -690,6 +690,24 @@ public class TaxonConceptInstance extends TaxonomicElement<TaxonConceptInstance,
     }
 
     /**
+     * Add a classification hint.
+     * <p>
+     * If the hint is null or there is already a classification value, don't bother.
+     * Otherwise, add the hint to the classification.
+     * </p>
+     *
+     * @param term The classifcation term
+     * @param value The hint value
+     */
+    public void addClassificationHint(Term term, @Nullable String value) {
+        if (value == null || (this.classification != null && this.classification.containsKey(term) && this.classification.get(term).isPresent()))
+            return;
+        if (this.classification == null)
+            this.classification = new HashMap<>();
+        this.classification.put(term, Optional.of(value));
+    }
+
+    /**
      * A provider/id pair to help locate this taxon.
      *
      * @return The locator
@@ -1508,7 +1526,7 @@ public class TaxonConceptInstance extends TaxonomicElement<TaxonConceptInstance,
      *
      * @return True if the scientific name is valid
      */
-    // If you plan to change this, it is called by a parallel stream, so consisder thread safety
+    // If you plan to change this, it is called by a parallel stream, so consider thread safety
     @Override
     public boolean validate(Taxonomy taxonomy) {
         boolean valid = true;
@@ -1519,7 +1537,6 @@ public class TaxonConceptInstance extends TaxonomicElement<TaxonConceptInstance,
                 taxonomy.report(IssueType.VALIDATION, "instance.validation.noParent", this, null);
                 valid = false;
             }
-
         }
         if ((this.acceptedNameUsageID != null || this.acceptedNameUsage != null) && this.accepted == null) {
             if (this.provider.isLoose())

--- a/ala-name-matching-builder/src/main/java/au/org/ala/names/search/ALANameIndexer.java
+++ b/ala-name-matching-builder/src/main/java/au/org/ala/names/search/ALANameIndexer.java
@@ -619,11 +619,7 @@ public class ALANameIndexer {
             while ((values = reader.readNext()) != null) {
 
                 if (values != null && values.length >= 3) {
-                    Document doc = new Document();
-                    //doc.add(new Field("lsid", values[2], Store.NO, Index.NOT_ANALYZED));
-                    NameIndexField.LSID.store(values[2], doc);
-                    //doc.add(new Field("reallsid", values[1], Store.YES, Index.NO));
-                    NameIndexField.REAL_LSID.store(values[1], doc);
+                    Document doc = this.createIdentifierDocument(values[2], null, values[1]);
                     iw.addDocument(doc);
                 }
             }
@@ -741,6 +737,18 @@ public class ALANameIndexer {
             NameIndexField.LANGUAGE.store(language.toLowerCase().trim(), doc);
          }
 
+        return doc;
+    }
+
+
+    protected Document createIdentifierDocument(String id, String sn, String lsid) {
+        Document doc = new Document();
+        if (sn != null) {
+            NameIndexField.NAME.store(sn, doc);
+        }
+
+        NameIndexField.LSID.store(id, doc);
+        NameIndexField.REAL_LSID.store(lsid, doc);
         return doc;
     }
 

--- a/ala-name-matching-builder/src/test/java/au/org/ala/names/index/ALANameAnalyserTest.java
+++ b/ala-name-matching-builder/src/test/java/au/org/ala/names/index/ALANameAnalyserTest.java
@@ -46,7 +46,8 @@ public class ALANameAnalyserTest {
 
     @Test
     public void testKey1() throws Exception {
-        NameKey key = this.analyser.analyse("ICNAFP", "Hemigenia brachyphylla", "F.Muell.", "species");
+        NameAnalyser.AnalysisResult result = this.analyser.analyse("ICNAFP", "Hemigenia brachyphylla", "F.Muell.", "species");
+        NameKey key = result.getNameKey();
         assertEquals(NomenclaturalClassifier.BOTANICAL, key.getCode());
         assertEquals(NameType.SCIENTIFIC, key.getType());
         assertEquals("HEMIGENIA BRACHIPHILA", key.getScientificName());
@@ -55,7 +56,8 @@ public class ALANameAnalyserTest {
 
     @Test
     public void testKey2() throws Exception {
-        NameKey key = this.analyser.analyse("ICZN", "Abantiades ocellatus", "Tindale, 1932", "species");
+        NameAnalyser.AnalysisResult result = this.analyser.analyse("ICZN", "Abantiades ocellatus", "Tindale, 1932", "species");
+        NameKey key = result.getNameKey();
         assertEquals(NomenclaturalClassifier.ZOOLOGICAL, key.getCode());
         assertEquals(NameType.SCIENTIFIC, key.getType());
         assertEquals("ABANTIADES OCELATA", key.getScientificName());
@@ -64,7 +66,8 @@ public class ALANameAnalyserTest {
 
     @Test
     public void testKey3() throws Exception {
-        NameKey key = this.analyser.analyse("ICZN", "Abantiades ocellatus", "Tindale, 1932", "species");
+        NameAnalyser.AnalysisResult result = this.analyser.analyse("ICZN", "Abantiades ocellatus", "Tindale, 1932", "species");
+        NameKey key = result.getNameKey();
         assertEquals(NomenclaturalClassifier.ZOOLOGICAL, key.getCode());
         assertEquals(NameType.SCIENTIFIC, key.getType());
         assertEquals("ABANTIADES OCELATA", key.getScientificName());
@@ -74,14 +77,16 @@ public class ALANameAnalyserTest {
 
     @Test
     public void testKey4() throws Exception {
-        NameKey key = this.analyser.analyse("ICZN", "Chezala Subgroup 4", null, "genus");
+        NameAnalyser.AnalysisResult result = this.analyser.analyse("ICZN", "Chezala Subgroup 4", null, "genus");
+        NameKey key = result.getNameKey();
         assertEquals(NameType.PLACEHOLDER, key.getType());
         assertEquals("CHEZALA SUBGROUP 4", key.getScientificName());
     }
 
     @Test
     public void testKey5() throws Exception {
-        NameKey key = this.analyser.analyse("ICNAFP", "Convolvulus sect. Brewera", null, "genus");
+        NameAnalyser.AnalysisResult result = this.analyser.analyse("ICNAFP", "Convolvulus sect. Brewera", null, "genus");
+        NameKey key = result.getNameKey();
         assertEquals(NomenclaturalClassifier.BOTANICAL, key.getCode());
         assertEquals(NameType.SCIENTIFIC, key.getType());
         assertEquals("CONVOLVULUS BREWERA", key.getScientificName());
@@ -89,7 +94,8 @@ public class ALANameAnalyserTest {
 
     @Test
     public void testKey6() throws Exception {
-        NameKey key = this.analyser.analyse("ICNAFP", "Convolvulus sect. Brewera", null, "genus");
+        NameAnalyser.AnalysisResult result = this.analyser.analyse("ICNAFP", "Convolvulus sect. Brewera", null, "genus");
+        NameKey key = result.getNameKey();
         assertEquals(NomenclaturalClassifier.BOTANICAL, key.getCode());
         assertEquals(NameType.SCIENTIFIC, key.getType());
         assertEquals("CONVOLVULUS BREWERA", key.getScientificName());
@@ -98,21 +104,24 @@ public class ALANameAnalyserTest {
 
     @Test
     public void testKey7() throws Exception {
-        NameKey key = this.analyser.analyse("ICZN", "Incertae sedis", null, "species");
+        NameAnalyser.AnalysisResult result = this.analyser.analyse("ICZN", "Incertae sedis", null, "species");
+        NameKey key = result.getNameKey();
         assertEquals(NomenclaturalClassifier.ZOOLOGICAL, key.getCode());
         assertEquals(NameType.PLACEHOLDER, key.getType());
     }
 
     @Test
     public void testKey8() throws Exception {
-        NameKey key = this.analyser.analyse("ICZN", "Unplaced acacia", null, "species");
+        NameAnalyser.AnalysisResult result = this.analyser.analyse("ICZN", "Unplaced acacia", null, "species");
+        NameKey key = result.getNameKey();
         assertEquals(NomenclaturalClassifier.ZOOLOGICAL, key.getCode());
         assertEquals(NameType.PLACEHOLDER, key.getType());
     }
 
     @Test
     public void testKey9() throws Exception {
-        NameKey key = this.analyser.analyse("ICBN", "Entoloma sp. (C)", null, "species");
+        NameAnalyser.AnalysisResult result = this.analyser.analyse("ICBN", "Entoloma sp. (C)", null, "species");
+        NameKey key = result.getNameKey();
         assertEquals(NomenclaturalClassifier.BOTANICAL, key.getCode());
         assertEquals(NameType.INFORMAL, key.getType());
         assertEquals("ENTOLOMA C", key.getScientificName());
@@ -120,7 +129,8 @@ public class ALANameAnalyserTest {
 
     @Test
     public void testKey10() throws Exception {
-        NameKey key = this.analyser.analyse("ICNAFP", "Atriplex ser. Stipitata", null, "series botany");
+        NameAnalyser.AnalysisResult result = this.analyser.analyse("ICNAFP", "Atriplex ser. Stipitata", null, "series botany");
+        NameKey key = result.getNameKey();
         assertEquals(NomenclaturalClassifier.BOTANICAL, key.getCode());
         assertEquals(NameType.SCIENTIFIC, key.getType());
         assertEquals("ATRIPLEX STIPITATA", key.getScientificName());
@@ -128,7 +138,8 @@ public class ALANameAnalyserTest {
 
     @Test
     public void testKey11() throws Exception {
-        NameKey key = this.analyser.analyse("ICNAFP", "Atriplex stipitatum", null, "species");
+        NameAnalyser.AnalysisResult result = this.analyser.analyse("ICNAFP", "Atriplex stipitatum", null, "species");
+        NameKey key = result.getNameKey();
         assertEquals(NomenclaturalClassifier.BOTANICAL, key.getCode());
         assertEquals(NameType.SCIENTIFIC, key.getType());
         assertEquals("ATRIPLEX STIPITATA", key.getScientificName());
@@ -136,7 +147,8 @@ public class ALANameAnalyserTest {
 
     @Test
     public void testKey12() throws Exception {
-        NameKey key = this.analyser.analyse("ICNAFP", "Brachyscome 'Pilliga Posy'", null, "species");
+        NameAnalyser.AnalysisResult result = this.analyser.analyse("ICNAFP", "Brachyscome 'Pilliga Posy'", null, "species");
+        NameKey key = result.getNameKey();
         assertEquals(NomenclaturalClassifier.BOTANICAL, key.getCode());
         assertEquals(NameType.CULTIVAR, key.getType());
         assertEquals("BRACHYSCOME 'PILLIGA POSY'", key.getScientificName());
@@ -145,7 +157,8 @@ public class ALANameAnalyserTest {
 
     @Test
     public void testKey13() throws Exception {
-        NameKey key = this.analyser.analyse("ICNAFP", "Eucalyptus caesia 'Silver Princess'", null, "species");
+        NameAnalyser.AnalysisResult result = this.analyser.analyse("ICNAFP", "Eucalyptus caesia 'Silver Princess'", null, "species");
+        NameKey key = result.getNameKey();
         assertEquals(NomenclaturalClassifier.BOTANICAL, key.getCode());
         assertEquals(NameType.CULTIVAR, key.getType());
         assertEquals("EUCALYPTUS CAESIA 'SILVER PRINCESS'", key.getScientificName());
@@ -154,7 +167,8 @@ public class ALANameAnalyserTest {
 
     @Test
     public void testKey14() throws Exception {
-        NameKey key = this.analyser.analyse("ICNAFP", "Munida aff. amathea", null, "species");
+        NameAnalyser.AnalysisResult result = this.analyser.analyse("ICNAFP", "Munida aff. amathea", null, "species");
+        NameKey key = result.getNameKey();
         assertEquals(NomenclaturalClassifier.BOTANICAL, key.getCode());
         assertEquals(NameType.DOUBTFUL, key.getType());
         assertEquals("MUNIDA AFF AMATHEA", key.getScientificName());
@@ -163,7 +177,8 @@ public class ALANameAnalyserTest {
 
     @Test
     public void testKey15() throws Exception {
-        NameKey key = this.analyser.analyse("ICNAFP", "Munida aff amathea", null, "species");
+        NameAnalyser.AnalysisResult result = this.analyser.analyse("ICNAFP", "Munida aff amathea", null, "species");
+        NameKey key = result.getNameKey();
         assertEquals(NomenclaturalClassifier.BOTANICAL, key.getCode());
         assertEquals(NameType.DOUBTFUL, key.getType());
         assertEquals("MUNIDA AFF AMATHEA", key.getScientificName());
@@ -172,7 +187,8 @@ public class ALANameAnalyserTest {
 
     @Test
     public void testKey16() throws Exception {
-        NameKey key = this.analyser.analyse("ICNAFP", "Waminoa cf. brickneri", null, "species");
+        NameAnalyser.AnalysisResult result = this.analyser.analyse("ICNAFP", "Waminoa cf. brickneri", null, "species");
+        NameKey key = result.getNameKey();
         assertEquals(NomenclaturalClassifier.BOTANICAL, key.getCode());
         assertEquals(NameType.DOUBTFUL, key.getType());
         assertEquals("WAMINOA CF BRICKNERI", key.getScientificName());
@@ -181,7 +197,8 @@ public class ALANameAnalyserTest {
 
     @Test
     public void testKey17() throws Exception {
-        NameKey key = this.analyser.analyse(NomenclaturalClassifier.BOTANICAL, "Waminoa cf. brickneri", null, null, null, null, true);
+        NameAnalyser.AnalysisResult result = this.analyser.analyse(NomenclaturalClassifier.BOTANICAL, "Waminoa cf. brickneri", null, null, null, null, true);
+        NameKey key = result.getNameKey();
         assertEquals(NomenclaturalClassifier.BOTANICAL, key.getCode());
         assertEquals(NameType.DOUBTFUL, key.getType());
         assertEquals("WAMINOA CF BRICKNERI", key.getScientificName());
@@ -191,7 +208,8 @@ public class ALANameAnalyserTest {
     // Autonym test
     @Test
     public void testKey18() throws Exception {
-        NameKey key = this.analyser.analyse(NomenclaturalClassifier.BOTANICAL, "Gonocarpus micranthus Thunb. subsp. micranthus", null, null, null, null, false);
+        NameAnalyser.AnalysisResult result = this.analyser.analyse(NomenclaturalClassifier.BOTANICAL, "Gonocarpus micranthus Thunb. subsp. micranthus", null, null, null, null, false);
+        NameKey key = result.getNameKey();
         assertEquals(NomenclaturalClassifier.BOTANICAL, key.getCode());
         assertEquals(NameType.SCIENTIFIC, key.getType());
         assertEquals("GONOCARPUS MICRANTHUS MICRANTHUS", key.getScientificName());
@@ -201,7 +219,8 @@ public class ALANameAnalyserTest {
 
     @Test
     public void testKey19() throws Exception {
-        NameKey key = this.analyser.analyse(NomenclaturalClassifier.BOTANICAL, "Gonocarpus micranthus subsp. ramosissimus", "Orchard", null, null, null, false);
+        NameAnalyser.AnalysisResult result = this.analyser.analyse(NomenclaturalClassifier.BOTANICAL, "Gonocarpus micranthus subsp. ramosissimus", "Orchard", null, null, null, false);
+        NameKey key = result.getNameKey();
         assertEquals(NomenclaturalClassifier.BOTANICAL, key.getCode());
         assertEquals(NameType.SCIENTIFIC, key.getType());
         assertEquals("GONOCARPUS MICRANTUS RAMOSISIMA", key.getScientificName());
@@ -211,7 +230,8 @@ public class ALANameAnalyserTest {
 
     @Test
     public void testKey20() throws Exception {
-        NameKey key = this.analyser.analyse(NomenclaturalClassifier.BOTANICAL, "Gonocarpus micranthus subsp. ramosissimus Orchard", null, null, null, null, true);
+        NameAnalyser.AnalysisResult result = this.analyser.analyse(NomenclaturalClassifier.BOTANICAL, "Gonocarpus micranthus subsp. ramosissimus Orchard", null, null, null, null, true);
+        NameKey key = result.getNameKey();
         assertEquals(NomenclaturalClassifier.BOTANICAL, key.getCode());
         assertEquals(NameType.SCIENTIFIC, key.getType());
         assertEquals("GONOCARPUS MICRANTUS RAMOSISIMA", key.getScientificName());
@@ -221,7 +241,8 @@ public class ALANameAnalyserTest {
 
     @Test
     public void testKey21() throws Exception {
-        NameKey key = this.analyser.analyse(NomenclaturalClassifier.BOTANICAL, "Gonocarpus micranthus Thunb. subsp. micranthus", "Thunb.", null, null, null, false);
+        NameAnalyser.AnalysisResult result = this.analyser.analyse(NomenclaturalClassifier.BOTANICAL, "Gonocarpus micranthus Thunb. subsp. micranthus", "Thunb.", null, null, null, false);
+        NameKey key = result.getNameKey();
         assertEquals(NomenclaturalClassifier.BOTANICAL, key.getCode());
         assertEquals(NameType.SCIENTIFIC, key.getType());
         assertEquals("GONOCARPUS MICRANTHUS MICRANTHUS", key.getScientificName());
@@ -232,7 +253,8 @@ public class ALANameAnalyserTest {
     // Author without trailing year marker
     @Test
     public void testKey22() throws Exception {
-        NameKey key = this.analyser.analyse(NomenclaturalClassifier.BACTERIAL, "Gemmatimonas aurantiaca Zhang et al. amerlia ", "Zhang et al.", null, null, null, false);
+        NameAnalyser.AnalysisResult result = this.analyser.analyse(NomenclaturalClassifier.BACTERIAL, "Gemmatimonas aurantiaca Zhang et al. amerlia ", "Zhang et al.", null, null, null, false);
+        NameKey key = result.getNameKey();
         assertEquals(NomenclaturalClassifier.BACTERIAL, key.getCode());
         assertEquals(NameType.SCIENTIFIC, key.getType());
         assertEquals("GEMMATIMONAS AURANTIACA AMERLIA", key.getScientificName());
@@ -243,7 +265,8 @@ public class ALANameAnalyserTest {
     // Author with trailing year marker
     @Test
     public void testKey23() throws Exception {
-        NameKey key = this.analyser.analyse(NomenclaturalClassifier.BACTERIAL, "Gemmatimonas aurantiaca Zhang et al., 1995", "Zhang et al.", null, null, null, false);
+        NameAnalyser.AnalysisResult result = this.analyser.analyse(NomenclaturalClassifier.BACTERIAL, "Gemmatimonas aurantiaca Zhang et al., 1995", "Zhang et al.", null, null, null, false);
+        NameKey key = result.getNameKey();
         assertEquals(NomenclaturalClassifier.BACTERIAL, key.getCode());
         assertEquals(NameType.SCIENTIFIC, key.getType());
         assertEquals("GEMMATIMONAS AURANTIACA", key.getScientificName());
@@ -254,7 +277,8 @@ public class ALANameAnalyserTest {
     // Author with trailing year marker
     @Test
     public void testKey24() throws Exception {
-        NameKey key = this.analyser.analyse(NomenclaturalClassifier.BACTERIAL, "Gemmatimonas aurantiaca Zhang et al., 1995 amerlia", "Zhang et al.", null, null, null, false);
+        NameAnalyser.AnalysisResult result = this.analyser.analyse(NomenclaturalClassifier.BACTERIAL, "Gemmatimonas aurantiaca Zhang et al., 1995 amerlia", "Zhang et al.", null, null, null, false);
+        NameKey key = result.getNameKey();
         assertEquals(NomenclaturalClassifier.BACTERIAL, key.getCode());
         assertEquals(NameType.SCIENTIFIC, key.getType());
         assertEquals("GEMMATIMONAS AURANTIACA AMERLIA", key.getScientificName());
@@ -266,20 +290,22 @@ public class ALANameAnalyserTest {
     // Test quoted genus
     @Test
     public void testKey25() throws Exception {
-        NameKey key = this.analyser.analyse(NomenclaturalClassifier.ZOOLOGICAL, "\"Hypomecis\" catephes", "(Turner, 1947)", null, null, null, false);
+        NameAnalyser.AnalysisResult result = this.analyser.analyse(NomenclaturalClassifier.ZOOLOGICAL, "\"Hypomecis\" catephes", "(Turner, 1947)", null, null, null, false);
+        NameKey key = result.getNameKey();
         assertEquals(NomenclaturalClassifier.ZOOLOGICAL, key.getCode());
         assertEquals(NameType.DOUBTFUL, key.getType());
         assertEquals("\"HYPOMECIS\" CATEPHES", key.getScientificName());
         assertEquals("(Turner, 1947)", key.getScientificNameAuthorship());
         assertEquals(RankType.UNRANKED, key.getRank());
-     }
+    }
 
 
     // Test aff. name looks like an author
     @Test
     public void testKey26() throws Exception {
         // With authot
-        NameKey key1 = this.analyser.analyse(null, "Carex aff. tereticaulis (Lake Omeo)", "sensu G.W. Carr", RankType.UNRANKED, TaxonomicType.INFERRED_UNPLACED, null, true);
+        NameAnalyser.AnalysisResult result1 = this.analyser.analyse(null, "Carex aff. tereticaulis (Lake Omeo)", "sensu G.W. Carr", RankType.UNRANKED, TaxonomicType.INFERRED_UNPLACED, null, true);
+        NameKey key1 = result1.getNameKey();
         assertEquals(null, key1.getCode());
         assertEquals(NameType.DOUBTFUL, key1.getType());
         assertEquals("CAREX AFF TERETICAULIS LAKE OMEO", key1.getScientificName());
@@ -287,7 +313,8 @@ public class ALANameAnalyserTest {
         assertEquals(RankType.UNRANKED, key1.getRank());
 
         // Without author
-        NameKey key2 = this.analyser.analyse(null, "Carex aff. tereticaulis (Lake Omeo)", null, RankType.UNRANKED, TaxonomicType.INFERRED_UNPLACED, null, true);
+        NameAnalyser.AnalysisResult result2 = this.analyser.analyse(null, "Carex aff. tereticaulis (Lake Omeo)", null, RankType.UNRANKED, TaxonomicType.INFERRED_UNPLACED, null, true);
+        NameKey key2 = result2.getNameKey();
         assertEquals(null, key2.getCode());
         assertEquals(NameType.DOUBTFUL, key2.getType());
         assertEquals("CAREX AFF TERETICAULIS LAKE OMEO", key2.getScientificName());
@@ -299,7 +326,8 @@ public class ALANameAnalyserTest {
     @Test
     public void testKey27() throws Exception {
         Set<TaxonFlag> flags = Collections.singleton(TaxonFlag.AMBIGUOUS_NOMENCLATURAL_CODE);
-        NameKey key1 = this.analyser.analyse(NomenclaturalClassifier.BOTANICAL, "Aulacoseira ambigua", "(Grunov) Simonsen", RankType.SPECIES, TaxonomicType.INFERRED_ACCEPTED, flags, true);
+        NameAnalyser.AnalysisResult result1 = this.analyser.analyse(NomenclaturalClassifier.BOTANICAL, "Aulacoseira ambigua", "(Grunov) Simonsen", RankType.SPECIES, TaxonomicType.INFERRED_ACCEPTED, flags, true);
+        NameKey key1 = result1.getNameKey();
         assertEquals(NomenclaturalClassifier.BOTANICAL, key1.getCode());
         assertEquals(NameType.SCIENTIFIC, key1.getType());
         assertEquals("AULACOSEIRA AMBIGUA", key1.getScientificName());
@@ -312,7 +340,8 @@ public class ALANameAnalyserTest {
     @Test
     public void testKey28() throws Exception {
         Set<TaxonFlag> flags = Collections.singleton(TaxonFlag.AMBIGUOUS_NOMENCLATURAL_CODE);
-        NameKey key1 = this.analyser.analyse(NomenclaturalClassifier.BOTANICAL, "Aulacoseira ambigua ambigua", "(Grunov) Simonsen", RankType.SPECIES, TaxonomicType.INFERRED_ACCEPTED, flags, true);
+        NameAnalyser.AnalysisResult result1 = this.analyser.analyse(NomenclaturalClassifier.BOTANICAL, "Aulacoseira ambigua ambigua", "(Grunov) Simonsen", RankType.SPECIES, TaxonomicType.INFERRED_ACCEPTED, flags, true);
+        NameKey key1 = result1.getNameKey();
         assertEquals(NomenclaturalClassifier.BOTANICAL, key1.getCode());
         assertEquals(NameType.SCIENTIFIC, key1.getType());
         assertEquals("AULACOSEIRA AMBIGUA AMBIGUA", key1.getScientificName());
@@ -326,14 +355,14 @@ public class ALANameAnalyserTest {
     @Test
     public void testAuthorEquals1() throws Exception {
         assertEquals(0, this.analyser.compareAuthor(null, null));
-        assertTrue( this.analyser.compareAuthor("L.", null) > 0);
+        assertTrue(this.analyser.compareAuthor("L.", null) > 0);
         assertTrue(this.analyser.compareAuthor(null, "L.") < 0);
     }
 
     @Test
     public void testAuthorEquals2() throws Exception {
         assertEquals(0, this.analyser.compareAuthor("Lindel", "Lindel"));
-        assertTrue( this.analyser.compareAuthor("Alphose", "Lindel") < 0);
+        assertTrue(this.analyser.compareAuthor("Alphose", "Lindel") < 0);
         assertTrue(this.analyser.compareAuthor("Lindel", "Alphonse") > 0);
     }
 
@@ -341,7 +370,7 @@ public class ALANameAnalyserTest {
     public void testAuthorEquals3() throws Exception {
         assertEquals(0, this.analyser.compareAuthor("L.", "Linnaeus"));
         assertEquals(0, this.analyser.compareAuthor("L.", "Lin."));
-     }
+    }
 
     // Ensure ex authors are treated properly
     @Test
@@ -353,79 +382,101 @@ public class ALANameAnalyserTest {
 
     @Test
     public void testKeyEquals1() throws Exception {
-        NameKey key1 = this.analyser.analyse(NomenclaturalClassifier.BOTANICAL, "Hemigenia brachyphylla F.Muell.", null, RankType.SPECIES, null, null, true);
-        NameKey key2 = this.analyser.analyse(NomenclaturalClassifier.BOTANICAL, "Hemigenia brachyphylla F.Mueller", null, RankType.SPECIES, null, null, true);
+        NameAnalyser.AnalysisResult result1 = this.analyser.analyse(NomenclaturalClassifier.BOTANICAL, "Hemigenia brachyphylla F.Muell.", null, RankType.SPECIES, null, null, true);
+        NameKey key1 = result1.getNameKey();
+        NameAnalyser.AnalysisResult result2 = this.analyser.analyse(NomenclaturalClassifier.BOTANICAL, "Hemigenia brachyphylla F.Mueller", null, RankType.SPECIES, null, null, true);
+        NameKey key2 = result2.getNameKey();
         assertTrue(key1.equals(key2));
     }
 
     @Test
     public void testKeyEquals2() throws Exception {
-        NameKey key1 = this.analyser.analyse("ICNAFP", "Hemigenia brachyphila", "F.Muell.", "species");
-        NameKey key2 = this.analyser.analyse("ICNAFP", "Hemigenia brachyphylla", "F.Muell.", "species");
+        NameAnalyser.AnalysisResult result1 = this.analyser.analyse("ICNAFP", "Hemigenia brachyphila", "F.Muell.", "species");
+        NameKey key1 = result1.getNameKey();
+        NameAnalyser.AnalysisResult result2 = this.analyser.analyse("ICNAFP", "Hemigenia brachyphylla", "F.Muell.", "species");
+        NameKey key2 = result2.getNameKey();
         assertTrue(key1.equals(key2));
     }
 
     @Test
     public void testKeyEquals3() throws Exception {
-        NameKey key1 = this.analyser.analyse("ICNAFP", "Hemigenia brachyphylla", "F.Muell.", "species");
-        NameKey key2 = this.analyser.analyse("ICNAFP", "Hemigenia brachyphylla", "F von Mueller", "species");
+        NameAnalyser.AnalysisResult result1 = this.analyser.analyse("ICNAFP", "Hemigenia brachyphylla", "F.Muell.", "species");
+        NameKey key1 = result1.getNameKey();
+        NameAnalyser.AnalysisResult result2 = this.analyser.analyse("ICNAFP", "Hemigenia brachyphylla", "F von Mueller", "species");
+        NameKey key2 = result2.getNameKey();
         assertTrue(key1.equals(key2));
     }
 
     @Test
     public void testkeyEquals4() throws Exception {
-        NameKey key1 = this.analyser.analyse("ICNAFP", "Hemigenia brachyphylla", "F.Muell.", "species");
-        NameKey key2 = this.analyser.analyse("ICZN", "Abantiades ocellatus", "Tindale, 1932", "species");
+        NameAnalyser.AnalysisResult result1 = this.analyser.analyse("ICNAFP", "Hemigenia brachyphylla", "F.Muell.", "species");
+        NameKey key1 = result1.getNameKey();
+        NameAnalyser.AnalysisResult result2 = this.analyser.analyse("ICZN", "Abantiades ocellatus", "Tindale, 1932", "species");
+        NameKey key2 = result2.getNameKey();
         assertFalse(key1.equals(key2));
     }
 
     @Test
     public void testkeyEquals5() throws Exception {
-        NameKey key1 = this.analyser.analyse("ICNAFP", "Bryidae", "Engl.", "subclass");
-        NameKey key2 = this.analyser.analyse("ICNAFP", "Bryidae", "Engler", "subclass");
+        NameAnalyser.AnalysisResult result1 = this.analyser.analyse("ICNAFP", "Bryidae", "Engl.", "subclass");
+        NameKey key1 = result1.getNameKey();
+        NameAnalyser.AnalysisResult result2 = this.analyser.analyse("ICNAFP", "Bryidae", "Engler", "subclass");
+        NameKey key2 = result2.getNameKey();
         assertTrue(key1.equals(key2));
     }
 
     @Test
     public void testkeyEquals6() throws Exception {
-        NameKey key1 = this.analyser.analyse("ICNAFP", "Bryidae", "Engl.", "subclass");
-        NameKey key2 = this.analyser.analyse("ICNAFP", "Bryidae", "Engler", "subclass");
+        NameAnalyser.AnalysisResult result1 = this.analyser.analyse("ICNAFP", "Bryidae", "Engl.", "subclass");
+        NameKey key1 = result1.getNameKey();
+        NameAnalyser.AnalysisResult result2 = this.analyser.analyse("ICNAFP", "Bryidae", "Engler", "subclass");
+        NameKey key2 = result2.getNameKey();
         assertTrue(key1.equals(key2));
     }
 
     @Test
     public void testkeyEquals7() throws Exception {
-        NameKey key1 = this.analyser.analyse("ICNAFP", "Bryidae", "Engl.", "subclass");
-        NameKey key2 = this.analyser.analyse("ICNAFP", "Bryidae", "H.G.A.Engler", "subclass");
+        NameAnalyser.AnalysisResult result1 = this.analyser.analyse("ICNAFP", "Bryidae", "Engl.", "subclass");
+        NameKey key1 = result1.getNameKey();
+        NameAnalyser.AnalysisResult result2 = this.analyser.analyse("ICNAFP", "Bryidae", "H.G.A.Engler", "subclass");
+        NameKey key2 = result2.getNameKey();
         assertTrue(key1.equals(key2));
     }
 
     @Test
     public void testkeyEquals8() throws Exception {
-        NameKey key1 = this.analyser.analyse("ICZN", "Typhinae", null, "subfamily");
-        NameKey key2 = this.analyser.analyse("ICZN", "Tiphiinae", null, "subfamily");
+        NameAnalyser.AnalysisResult result1 = this.analyser.analyse("ICZN", "Typhinae", null, "subfamily");
+        NameKey key1 = result1.getNameKey();
+        NameAnalyser.AnalysisResult result2 = this.analyser.analyse("ICZN", "Tiphiinae", null, "subfamily");
+        NameKey key2 = result2.getNameKey();
         assertFalse(key1.equals(key2));
     }
 
     @Test
     public void testkeyEquals9() throws Exception {
-        NameKey key1 = this.analyser.analyse("ICZN", "Amenia (imperialis group)", null, "species group");
-        NameKey key2 = this.analyser.analyse("ICZN", "Amenia (leonina group)", null, "species group");
+        NameAnalyser.AnalysisResult result1 = this.analyser.analyse("ICZN", "Amenia (imperialis group)", null, "species group");
+        NameKey key1 = result1.getNameKey();
+        NameAnalyser.AnalysisResult result2 = this.analyser.analyse("ICZN", "Amenia (leonina group)", null, "species group");
+        NameKey key2 = result2.getNameKey();
         assertFalse(key1.equals(key2));
     }
 
     @Test
     public void testkeyEquals10() throws Exception {
-        NameKey key1 = this.analyser.analyse("ICNAFP", "Atriplex ser. Stipitata", null, "series botany");
-        NameKey key2 = this.analyser.analyse("ICNAFP", "Atriplex stipitatum", null, "species");
+        NameAnalyser.AnalysisResult result1 = this.analyser.analyse("ICNAFP", "Atriplex ser. Stipitata", null, "series botany");
+        NameKey key1 = result1.getNameKey();
+        NameAnalyser.AnalysisResult result2 = this.analyser.analyse("ICNAFP", "Atriplex stipitatum", null, "species");
+        NameKey key2 = result2.getNameKey();
         assertFalse(key1.equals(key2));
     }
 
     // Loose names
     @Test
     public void testkeyEquals11() throws Exception {
-        NameKey key1 = this.analyser.analyse(null, "Acaena rorida", "B.H.Macmill.", null, null, null, false);
-        NameKey key2 = this.analyser.analyse(null, "Acaena rorida B.H.Macmill.", null, null, null, null, true);
+        NameAnalyser.AnalysisResult result1 = this.analyser.analyse(null, "Acaena rorida", "B.H.Macmill.", null, null, null, false);
+        NameKey key1 = result1.getNameKey();
+        NameAnalyser.AnalysisResult result2 = this.analyser.analyse(null, "Acaena rorida B.H.Macmill.", null, null, null, null, true);
+        NameKey key2 = result2.getNameKey();
         assertTrue(key1.equals(key2));
     }
 
@@ -433,59 +484,75 @@ public class ALANameAnalyserTest {
     // Cultivar names
     @Test
     public void testkeyEquals12() throws Exception {
-        NameKey key1 = this.analyser.analyse(null, "Acacia dealbata 'Morning Glory'", null, "species");
-        NameKey key2 = this.analyser.analyse(null, "Acacia dealbata Morning Glory", null, "species");
+        NameAnalyser.AnalysisResult result1 = this.analyser.analyse(null, "Acacia dealbata 'Morning Glory'", null, "species");
+        NameKey key1 = result1.getNameKey();
+        NameAnalyser.AnalysisResult result2 = this.analyser.analyse(null, "Acacia dealbata Morning Glory", null, "species");
+        NameKey key2 = result2.getNameKey();
         assertFalse(key1.equals(key2));
     }
 
     @Test
     public void testKeyEquals13() throws Exception {
-        NameKey key1 = this.analyser.analyse("ICNAFP", "Hemigenia brachyphylla", "F.Muell.", "species");
-        NameKey key2 = this.analyser.analyse("ICNAFP", "Hemigenia brachyphylla", "F. Muell.", "species");
+        NameAnalyser.AnalysisResult result1 = this.analyser.analyse("ICNAFP", "Hemigenia brachyphylla", "F.Muell.", "species");
+        NameKey key1 = result1.getNameKey();
+        NameAnalyser.AnalysisResult result2 = this.analyser.analyse("ICNAFP", "Hemigenia brachyphylla", "F. Muell.", "species");
+        NameKey key2 = result2.getNameKey();
         assertTrue(key1.equals(key2));
     }
 
     @Test
     public void testKeyEquals14() throws Exception {
-        NameKey key1 = this.analyser.analyse("ICNAFP", "Hemigenia brachyphylla", "A.F. Nurke", "species");
-        NameKey key2 = this.analyser.analyse("ICNAFP", "Hemigenia brachyphylla", "A.F.Nurke", "species");
+        NameAnalyser.AnalysisResult result1 = this.analyser.analyse("ICNAFP", "Hemigenia brachyphylla", "A.F. Nurke", "species");
+        NameKey key1 = result1.getNameKey();
+        NameAnalyser.AnalysisResult result2 = this.analyser.analyse("ICNAFP", "Hemigenia brachyphylla", "A.F.Nurke", "species");
+        NameKey key2 = result2.getNameKey();
         assertTrue(key1.equals(key2));
     }
 
     @Test
     public void testKeyEquals15() throws Exception {
-        NameKey key1 = this.analyser.analyse("ICNAFP", "Hemigenia brachyphylla", "A.F. Nûrke", "species");
-        NameKey key2 = this.analyser.analyse("ICNAFP", "Hemigenia brachyphylla", "A.F. Nurke", "species");
+        NameAnalyser.AnalysisResult result1 = this.analyser.analyse("ICNAFP", "Hemigenia brachyphylla", "A.F. Nûrke", "species");
+        NameKey key1 = result1.getNameKey();
+        NameAnalyser.AnalysisResult result2 = this.analyser.analyse("ICNAFP", "Hemigenia brachyphylla", "A.F. Nurke", "species");
+        NameKey key2 = result2.getNameKey();
         assertTrue(key1.equals(key2));
     }
 
     @Test
     public void testKeyEquals16() throws Exception {
-        NameKey key1 = this.analyser.analyse("ICNAFP", "Hemigenia brachyphylla", "A. Nurke", "species");
-        NameKey key2 = this.analyser.analyse("ICNAFP", "Hemigenia brachyphylla", "A Nurke", "species");
+        NameAnalyser.AnalysisResult result1 = this.analyser.analyse("ICNAFP", "Hemigenia brachyphylla", "A. Nurke", "species");
+        NameKey key1 = result1.getNameKey();
+        NameAnalyser.AnalysisResult result2 = this.analyser.analyse("ICNAFP", "Hemigenia brachyphylla", "A Nurke", "species");
+        NameKey key2 = result2.getNameKey();
         assertTrue(key1.equals(key2));
     }
 
     // Placeholder names
     @Test
     public void testKeyEquals17() throws Exception {
-        NameKey key1 = this.analyser.analyse(NomenclaturalClassifier.BOTANICAL, "Incertae sedis", "F.Muell.", RankType.SPECIES, TaxonomicType.ACCEPTED, null, false);
-        NameKey key2 = this.analyser.analyse(NomenclaturalClassifier.BOTANICAL, "Incertae sedis", "F.Muell.", RankType.SPECIES, TaxonomicType.ACCEPTED, null, false);
+        NameAnalyser.AnalysisResult result1 = this.analyser.analyse(NomenclaturalClassifier.BOTANICAL, "Incertae sedis", "F.Muell.", RankType.SPECIES, TaxonomicType.ACCEPTED, null, false);
+        NameKey key1 = result1.getNameKey();
+        NameAnalyser.AnalysisResult result2 = this.analyser.analyse(NomenclaturalClassifier.BOTANICAL, "Incertae sedis", "F.Muell.", RankType.SPECIES, TaxonomicType.ACCEPTED, null, false);
+        NameKey key2 = result2.getNameKey();
         assertFalse(key1.equals(key2));
     }
 
     @Test
     public void testKeyEquals18() throws Exception {
-        NameKey key1 = this.analyser.analyse(NomenclaturalClassifier.BOTANICAL, "Hemigenia brachyphylla", "F.Muell.", RankType.SPECIES, TaxonomicType.INCERTAE_SEDIS, null, false);
-        NameKey key2 = this.analyser.analyse(NomenclaturalClassifier.BOTANICAL, "Hemigenia brachyphylla", "F.Muell.", RankType.SPECIES, TaxonomicType.INCERTAE_SEDIS, null, false);
+        NameAnalyser.AnalysisResult result1 = this.analyser.analyse(NomenclaturalClassifier.BOTANICAL, "Hemigenia brachyphylla", "F.Muell.", RankType.SPECIES, TaxonomicType.INCERTAE_SEDIS, null, false);
+        NameKey key1 = result1.getNameKey();
+        NameAnalyser.AnalysisResult result2 = this.analyser.analyse(NomenclaturalClassifier.BOTANICAL, "Hemigenia brachyphylla", "F.Muell.", RankType.SPECIES, TaxonomicType.INCERTAE_SEDIS, null, false);
+        NameKey key2 = result2.getNameKey();
         assertFalse(key1.equals(key2));
     }
 
     // Autonyms
     @Test
     public void testKeyEquals19() throws Exception {
-        NameKey key1 = this.analyser.analyse(NomenclaturalClassifier.BOTANICAL, "Senecio glomeratus Desf. ex Poir. subsp. glomeratus", null, null, null, null, false);
-        NameKey key2 = this.analyser.analyse(NomenclaturalClassifier.BOTANICAL, "Senecio glomeratus Poir. subsp. glomeratus", "Poir.", null, null, null, false);
+        NameAnalyser.AnalysisResult result1 = this.analyser.analyse(NomenclaturalClassifier.BOTANICAL, "Senecio glomeratus Desf. ex Poir. subsp. glomeratus", null, null, null, null, false);
+        NameKey key1 = result1.getNameKey();
+        NameAnalyser.AnalysisResult result2 = this.analyser.analyse(NomenclaturalClassifier.BOTANICAL, "Senecio glomeratus Poir. subsp. glomeratus", "Poir.", null, null, null, false);
+        NameKey key2 = result2.getNameKey();
         assertTrue(key1.isAutonym());
         assertTrue(key2.isAutonym());
         assertEquals(key1, key2);
@@ -494,55 +561,149 @@ public class ALANameAnalyserTest {
     // Escaped letters
     @Test
     public void testKeyEquals20() throws Exception {
-        NameKey key1 = this.analyser.analyse(NomenclaturalClassifier.BOTANICAL, "Senecio \\glomeratus", "Poir.", null, null, null, false);
-        NameKey key2 = this.analyser.analyse(NomenclaturalClassifier.BOTANICAL, "Senecio glomeratus", "Poir.", null, null, null, false);
+        NameAnalyser.AnalysisResult result1 = this.analyser.analyse(NomenclaturalClassifier.BOTANICAL, "Senecio \\glomeratus", "Poir.", null, null, null, false);
+        NameKey key1 = result1.getNameKey();
+        NameAnalyser.AnalysisResult result2 = this.analyser.analyse(NomenclaturalClassifier.BOTANICAL, "Senecio glomeratus", "Poir.", null, null, null, false);
+        NameKey key2 = result2.getNameKey();
         assertEquals(key1, key2);
     }
 
     @Test
     public void testKeyEquals21() throws Exception {
-        NameKey key1 = this.analyser.analyse(NomenclaturalClassifier.BOTANICAL, "Senecio glomeratus", "\\(Poir\\.\\)", null, null, null, false);
-        NameKey key2 = this.analyser.analyse(NomenclaturalClassifier.BOTANICAL, "Senecio glomeratus", "(Poir.)", null, null, null, false);
+        NameAnalyser.AnalysisResult result1 = this.analyser.analyse(NomenclaturalClassifier.BOTANICAL, "Senecio glomeratus", "\\(Poir\\.\\)", null, null, null, false);
+        NameKey key1 = result1.getNameKey();
+        NameAnalyser.AnalysisResult result2 = this.analyser.analyse(NomenclaturalClassifier.BOTANICAL, "Senecio glomeratus", "(Poir.)", null, null, null, false);
+        NameKey key2 = result2.getNameKey();
         assertEquals(key1, key2);
     }
 
     // Ampersands
     @Test
     public void testKeyEquals22() throws Exception {
-        NameKey key1 = this.analyser.analyse(NomenclaturalClassifier.BOTANICAL, "Senecio glomeratus", "Poir.  and Labil", null, null, null, false);
-        NameKey key2 = this.analyser.analyse(NomenclaturalClassifier.BOTANICAL, "Senecio glomeratus", "Poir. &  Labil", null, null, null, false);
+        NameAnalyser.AnalysisResult result1 = this.analyser.analyse(NomenclaturalClassifier.BOTANICAL, "Senecio glomeratus", "Poir.  and Labil", null, null, null, false);
+        NameKey key1 = result1.getNameKey();
+        NameAnalyser.AnalysisResult result2 = this.analyser.analyse(NomenclaturalClassifier.BOTANICAL, "Senecio glomeratus", "Poir. &  Labil", null, null, null, false);
+        NameKey key2 = result2.getNameKey();
         assertEquals(key1, key2);
     }
 
     // Changed combination marker
     @Test
     public void testKeyEquals23() throws Exception {
-        NameKey key1 = this.analyser.analyse(NomenclaturalClassifier.ZOOLOGICAL, "Osphranter rufus", "Desmarest, 1822", null, null, null, false);
-        NameKey key2 = this.analyser.analyse(NomenclaturalClassifier.ZOOLOGICAL, "Osphranter rufus", "(Desmarest, 1822)", null, null, null, false);
+        NameAnalyser.AnalysisResult result1 = this.analyser.analyse(NomenclaturalClassifier.ZOOLOGICAL, "Osphranter rufus", "Desmarest, 1822", null, null, null, false);
+        NameKey key1 = result1.getNameKey();
+        NameAnalyser.AnalysisResult result2 = this.analyser.analyse(NomenclaturalClassifier.ZOOLOGICAL, "Osphranter rufus", "(Desmarest, 1822)", null, null, null, false);
+        NameKey key2 = result2.getNameKey();
         assertEquals(key1, key2);
     }
 
     // Placeholder names
     @Test
     public void testKeyEquals24() throws Exception {
-        NameKey key1 = this.analyser.analyse(NomenclaturalClassifier.ZOOLOGICAL, "Galaxias sp. 3", null, null, null, null, false);
-        NameKey key2 = this.analyser.analyse(NomenclaturalClassifier.ZOOLOGICAL, "Galaxias sp 3", null, null, null, null, false);
+        NameAnalyser.AnalysisResult result1 = this.analyser.analyse(NomenclaturalClassifier.ZOOLOGICAL, "Galaxias sp. 3", null, null, null, null, false);
+        NameKey key1 = result1.getNameKey();
+        NameAnalyser.AnalysisResult result2 = this.analyser.analyse(NomenclaturalClassifier.ZOOLOGICAL, "Galaxias sp 3", null, null, null, null, false);
+        NameKey key2 = result2.getNameKey();
         assertEquals(key1, key2);
     }
 
     @Test
     public void testKeyEquals25() throws Exception {
-        NameKey key1 = this.analyser.analyse(NomenclaturalClassifier.ZOOLOGICAL, "Galaxias sp. 3", null, null, null, null, false);
-        NameKey key2 = this.analyser.analyse(NomenclaturalClassifier.ZOOLOGICAL, "Galaxias sp 3", null, null, null, null, true);
+        NameAnalyser.AnalysisResult result1 = this.analyser.analyse(NomenclaturalClassifier.ZOOLOGICAL, "Galaxias sp. 3", null, null, null, null, false);
+        NameKey key1 = result1.getNameKey();
+        NameAnalyser.AnalysisResult result2 = this.analyser.analyse(NomenclaturalClassifier.ZOOLOGICAL, "Galaxias sp 3", null, null, null, null, true);
+        NameKey key2 = result2.getNameKey();
         assertEquals(key1, key2);
     }
 
     // Initially quoted names
     @Test
     public void testKeyEquals26() throws Exception {
-        NameKey key1 = this.analyser.analyse(NomenclaturalClassifier.ZOOLOGICAL, "\"Hypomecis\" catephes", null, RankType.SPECIES, null, null, false);
-        NameKey key2 = this.analyser.analyse(NomenclaturalClassifier.ZOOLOGICAL, "Hypomecis catephes", null, RankType.SPECIES, null, null, false);
+        NameAnalyser.AnalysisResult result1 = this.analyser.analyse(NomenclaturalClassifier.ZOOLOGICAL, "\"Hypomecis\" catephes", null, RankType.SPECIES, null, null, false);
+        NameKey key1 = result1.getNameKey();
+        NameAnalyser.AnalysisResult result2 = this.analyser.analyse(NomenclaturalClassifier.ZOOLOGICAL, "Hypomecis catephes", null, RankType.SPECIES, null, null, false);
+        NameKey key2 = result2.getNameKey();
         assertNotEquals(key1, key2);
+    }
+
+    @Test
+    public void testNames1() throws Exception {
+        NameAnalyser.AnalysisResult result = this.analyser.analyse("ICZN", "Abantiades ocellatus", "Tindale, 1932", "species");
+        assertEquals("Abantiades", result.getMononomial());
+        assertEquals("Abantiades", result.getGenus());
+        assertEquals("ocellatus", result.getSpecificEpithet());
+        assertNull(result.getInfraspecificEpithet());
+        assertNull(result.getCultivarEpithet());
+    }
+
+    @Test
+    public void testNames2() throws Exception {
+        NameAnalyser.AnalysisResult result = this.analyser.analyse("ICBN", "Plantae", "Haekel", "kingdom");
+        assertEquals("Plantae", result.getMononomial());
+        assertNull(result.getGenus());
+        assertNull(result.getSpecificEpithet());
+        assertNull(result.getInfraspecificEpithet());
+        assertNull(result.getCultivarEpithet());
+    }
+
+    @Test
+    public void testNames3() throws Exception {
+        NameAnalyser.AnalysisResult result = this.analyser.analyse("ICZN", "Chezala Subgroup 4", null, "genus");
+        assertEquals("Chezala", result.getMononomial());
+        assertEquals("Chezala", result.getGenus());
+        assertEquals("Subgroup-4", result.getSpecificEpithet());
+        assertNull(result.getInfraspecificEpithet());
+        assertNull(result.getCultivarEpithet());
+    }
+
+    @Test
+    public void testNames4() throws Exception {
+        NameAnalyser.AnalysisResult result = this.analyser.analyse("ICNAFP", "Convolvulus sect. Brewera", null, "genus");
+        assertEquals("Convolvulus", result.getMononomial());
+        assertEquals("Convolvulus", result.getGenus());
+        assertNull(result.getSpecificEpithet());
+        assertNull(result.getInfraspecificEpithet());
+        assertNull(result.getCultivarEpithet());
+    }
+
+    @Test
+    public void testNames5() throws Exception {
+        NameAnalyser.AnalysisResult result = this.analyser.analyse("ICNAFP", "Brachyscome 'Pilliga Posy'", null, null);
+        assertEquals("Brachyscome", result.getMononomial());
+        assertEquals("Brachyscome", result.getGenus());
+        assertNull(result.getSpecificEpithet());
+        assertNull(result.getInfraspecificEpithet());
+        assertEquals("Pilliga Posy", result.getCultivarEpithet());
+    }
+
+    @Test
+    public void testNames6() throws Exception {
+        NameAnalyser.AnalysisResult result = this.analyser.analyse("ICNAFP", "Eucalyptus caesia 'Silver Princess'", null, null);
+        assertEquals("Eucalyptus", result.getMononomial());
+        assertEquals("Eucalyptus", result.getGenus());
+        assertEquals("caesia", result.getSpecificEpithet());
+        assertNull(result.getInfraspecificEpithet());
+        assertEquals("Silver Princess", result.getCultivarEpithet());
+    }
+
+    @Test
+    public void testNames7() throws Exception {
+        NameAnalyser.AnalysisResult result = this.analyser.analyse("ICNAFP", "Waminoa cf. brickneri", null, "species");
+        assertEquals("Waminoa", result.getMononomial());
+        assertEquals("Waminoa", result.getGenus());
+        assertEquals("brickneri", result.getSpecificEpithet());
+        assertNull(result.getInfraspecificEpithet());
+        assertNull( result.getCultivarEpithet());
+    }
+
+    @Test
+    public void testNames8() throws Exception {
+        NameAnalyser.AnalysisResult result = this.analyser.analyse("ICNAFP", "Acacia dealbata subalpina", null, "subspecies");
+        assertEquals("Acacia", result.getMononomial());
+        assertEquals("Acacia", result.getGenus());
+        assertEquals("dealbata", result.getSpecificEpithet());
+        assertEquals("subalpina", result.getInfraspecificEpithet());
+        assertNull(result.getCultivarEpithet());
     }
 
     @Test
@@ -568,7 +729,7 @@ public class ALANameAnalyserTest {
         TaxonomicType status = this.analyser.canonicaliseTaxonomicType("synonym");
         assertEquals(TaxonomicType.SYNONYM, status);
     }
-    
+
     @Test
     public void testCanonicaliseTaxonomicType3() throws Exception {
         TaxonomicType status = this.analyser.canonicaliseTaxonomicType("");
@@ -627,7 +788,7 @@ public class ALANameAnalyserTest {
     public void testCanonicaliseRankType4() throws Exception {
         RankType rank = this.analyser.canonicaliseRank("something else");
         assertEquals(RankType.UNRANKED, rank);
-     }
+    }
 
     @Test
     public void testCanonicaliseNomenclaturalStatus1() throws Exception {

--- a/ala-name-matching-builder/src/test/java/au/org/ala/names/index/ALANameAnalyserTest.java
+++ b/ala-name-matching-builder/src/test/java/au/org/ala/names/index/ALANameAnalyserTest.java
@@ -352,6 +352,41 @@ public class ALANameAnalyserTest {
         assertTrue(key1.getFlags().contains(TaxonFlag.AMBIGUOUS_NOMENCLATURAL_CODE));
     }
 
+    // Test misc literature
+    @Test
+    public void testKey29() throws Exception {
+        NameAnalyser.AnalysisResult result1 = this.analyser.analyse(NomenclaturalClassifier.ZOOLOGICAL, "Genus B", null, RankType.UNRANKED, TaxonomicType.MISCELLANEOUS_LITERATURE, null, false);
+        NameKey key1 = result1.getNameKey();
+        assertEquals(NomenclaturalClassifier.ZOOLOGICAL, key1.getCode());
+        assertEquals(NameType.INFORMAL, key1.getType());
+        assertEquals("GENUS B", key1.getScientificName());
+        assertNull(key1.getScientificNameAuthorship());
+        assertEquals(RankType.UNRANKED, key1.getRank());
+        assertNull(key1.getFlags());
+        assertNull(result1.getMononomial());
+        assertNull(result1.getGenus());
+        assertNull(result1.getSpecificEpithet());
+        assertNull(result1.getInfraspecificEpithet());
+    }
+
+
+    // Test obvious placeholder
+    @Test
+    public void testKey30() throws Exception {
+        NameAnalyser.AnalysisResult result1 = this.analyser.analyse(NomenclaturalClassifier.ZOOLOGICAL, "Genus B sp.", null, null, null, null, false);
+        NameKey key1 = result1.getNameKey();
+        assertEquals(NomenclaturalClassifier.ZOOLOGICAL, key1.getCode());
+        assertEquals(NameType.INFORMAL, key1.getType());
+        assertEquals("GENUS B SP", key1.getScientificName());
+        assertNull(key1.getScientificNameAuthorship());
+        assertEquals(RankType.SPECIES, key1.getRank());
+        assertNull(key1.getFlags());
+        assertNull(result1.getMononomial());
+        assertNull(result1.getGenus());
+        assertNull(result1.getSpecificEpithet());
+        assertNull(result1.getInfraspecificEpithet());
+    }
+
     @Test
     public void testAuthorEquals1() throws Exception {
         assertEquals(0, this.analyser.compareAuthor(null, null));

--- a/ala-name-matching-builder/src/test/java/au/org/ala/names/index/NameProviderTest.java
+++ b/ala-name-matching-builder/src/test/java/au/org/ala/names/index/NameProviderTest.java
@@ -129,13 +129,13 @@ public class NameProviderTest extends TestUtils {
     public void testForbid1() {
         NameProvider provider = this.getProvider("ID-5");
         TaxonConceptInstance instance1 = this.createInstance("ID-1", NomenclaturalClassifier.BOTANICAL, "Acacia dealbata", provider);
-        NameKey key1 = this.analyser.analyse(instance1);
+        NameKey key1 = this.analyser.analyse(instance1).getNameKey();
         TaxonConceptInstance instance2 = this.createInstance("ID-1", NomenclaturalClassifier.BOTANICAL, "Acacia", provider);
-        NameKey key2 = this.analyser.analyse(instance2);
+        NameKey key2 = this.analyser.analyse(instance2).getNameKey();
         TaxonConceptInstance instance3 = this.createInstance("ID-1", NomenclaturalClassifier.ZOOLOGICAL, "Macropus", provider);
-        NameKey key3 = this.analyser.analyse(instance3);
+        NameKey key3 = this.analyser.analyse(instance3).getNameKey();
         TaxonConceptInstance instance4 = this.createInstance("ID-1", NomenclaturalClassifier.ZOOLOGICAL, "Macropus", provider, TaxonomicType.INCERTAE_SEDIS);
-        NameKey key4 = this.analyser.analyse(instance4);
+        NameKey key4 = this.analyser.analyse(instance4).getNameKey();
         assertNull(provider.forbid(instance1, key1));
         assertNull(provider.forbid(instance2, key2));
         assertNull(provider.forbid(instance3, key3));
@@ -147,13 +147,13 @@ public class NameProviderTest extends TestUtils {
     public void testForbid2() {
         NameProvider provider = this.getProvider("ID-6");
         TaxonConceptInstance instance1 = this.createInstance("ID-1", NomenclaturalClassifier.BOTANICAL, "Acacia dealbata", provider);
-        NameKey key1 = this.analyser.analyse(instance1);
+        NameKey key1 = this.analyser.analyse(instance1).getNameKey();
         TaxonConceptInstance instance2 = this.createInstance("ID-1", NomenclaturalClassifier.BOTANICAL, "Acacia", provider, TaxonomicType.EXCLUDED);
-        NameKey key2 = this.analyser.analyse(instance2);
+        NameKey key2 = this.analyser.analyse(instance2).getNameKey();
         TaxonConceptInstance instance3 = this.createInstance("ID-1", NomenclaturalClassifier.ZOOLOGICAL, "Macropus", provider);
-        NameKey key3 = this.analyser.analyse(instance3);
+        NameKey key3 = this.analyser.analyse(instance3).getNameKey();
         TaxonConceptInstance instance4 = this.createInstance("ID-1", NomenclaturalClassifier.ZOOLOGICAL, "Macropus", provider, TaxonomicType.INCERTAE_SEDIS);
-        NameKey key4 = this.analyser.analyse(instance4);
+        NameKey key4 = this.analyser.analyse(instance4).getNameKey();
         assertNull(provider.forbid(instance1, key1));
         assertEquals("taxonomicStatus:EXCLUDED", provider.forbid(instance2, key2));
         assertNull(provider.forbid(instance3, key3));

--- a/ala-name-matching-builder/src/test/java/au/org/ala/names/index/ScientificNameTest.java
+++ b/ala-name-matching-builder/src/test/java/au/org/ala/names/index/ScientificNameTest.java
@@ -76,7 +76,7 @@ public class ScientificNameTest {
                 null,
                 null
         );
-        NameKey instanceKey = this.analyser.analyse(NomenclaturalClassifier.ZOOLOGICAL, NAME_1, AUTHOR_1, RankType.SPECIES, null, null, false);
+        NameKey instanceKey = this.analyser.analyse(NomenclaturalClassifier.ZOOLOGICAL, NAME_1, AUTHOR_1, RankType.SPECIES, null, null, false).getNameKey();
         NameKey nameKey = instanceKey.toNameKey();
         ScientificName name = new ScientificName(null, nameKey);
         name.addInstance(instanceKey, instance);

--- a/ala-name-matching-builder/src/test/java/au/org/ala/names/index/TaxonConceptTest.java
+++ b/ala-name-matching-builder/src/test/java/au/org/ala/names/index/TaxonConceptTest.java
@@ -72,7 +72,7 @@ public class TaxonConceptTest {
                 null,
                 null
         );
-        NameKey instanceKey = this.analyser.analyse(NomenclaturalClassifier.ZOOLOGICAL, NAME_1, AUTHOR_1, RankType.SPECIES, null, null, false);
+        NameKey instanceKey = this.analyser.analyse(NomenclaturalClassifier.ZOOLOGICAL, NAME_1, AUTHOR_1, RankType.SPECIES, null, null, false).getNameKey();
         NameKey nameKey = instanceKey.toNameKey();
         ScientificName name = new ScientificName(null, nameKey);
         TaxonConcept concept = new TaxonConcept(name, nameKey);

--- a/ala-name-matching-builder/src/test/java/au/org/ala/names/index/provider/AndTaxonConditionTest.java
+++ b/ala-name-matching-builder/src/test/java/au/org/ala/names/index/provider/AndTaxonConditionTest.java
@@ -53,7 +53,7 @@ public class AndTaxonConditionTest extends TestUtils {
         condition1.setNomenclaturalCode(NomenclaturalClassifier.BOTANICAL);
         condition.add(condition1);
         TaxonConceptInstance instance = this.createInstance("ID-1", NomenclaturalClassifier.BOTANICAL, "Acacia dealbata", this.provider, TaxonomicType.HOMOTYPIC_SYNONYM);
-        NameKey key = this.analyser.analyse(instance);
+        NameKey key = this.analyser.analyse(instance).getNameKey();
         assertTrue(condition.match(instance, key));
     }
 
@@ -64,7 +64,7 @@ public class AndTaxonConditionTest extends TestUtils {
         condition1.setNomenclaturalCode(NomenclaturalClassifier.ZOOLOGICAL);
         condition.add(condition1);
         TaxonConceptInstance instance = this.createInstance("ID-1", NomenclaturalClassifier.BOTANICAL, "Acacia dealbata", this.provider, TaxonomicType.HOMOTYPIC_SYNONYM);
-        NameKey key = this.analyser.analyse(instance);
+        NameKey key = this.analyser.analyse(instance).getNameKey();
         assertFalse(condition.match(instance, key));
     }
 
@@ -79,7 +79,7 @@ public class AndTaxonConditionTest extends TestUtils {
         condition.add(condition1);
         condition.add(condition2);
         TaxonConceptInstance instance = this.createInstance("ID-1", NomenclaturalClassifier.BOTANICAL, "Acacia dealbata", this.provider, TaxonomicType.HOMOTYPIC_SYNONYM);
-        NameKey key = this.analyser.analyse(instance);
+        NameKey key = this.analyser.analyse(instance).getNameKey();
         assertTrue(condition.match(instance, key));
     }
 
@@ -93,7 +93,7 @@ public class AndTaxonConditionTest extends TestUtils {
         condition.add(condition1);
         condition.add(condition2);
         TaxonConceptInstance instance = this.createInstance("ID-1", NomenclaturalClassifier.ZOOLOGICAL, "Acacia dealbata", this.provider, TaxonomicType.HOMOTYPIC_SYNONYM);
-        NameKey key = this.analyser.analyse(instance);
+        NameKey key = this.analyser.analyse(instance).getNameKey();
         assertFalse(condition.match(instance, key));
     }
 
@@ -107,7 +107,7 @@ public class AndTaxonConditionTest extends TestUtils {
         condition.add(condition1);
         condition.add(condition2);
         TaxonConceptInstance instance = this.createInstance("ID-1", NomenclaturalClassifier.BOTANICAL, "Acacia dealbata", this.provider, TaxonomicType.ACCEPTED);
-        NameKey key = this.analyser.analyse(instance);
+        NameKey key = this.analyser.analyse(instance).getNameKey();
         assertFalse(condition.match(instance, key));
     }
 
@@ -132,10 +132,10 @@ public class AndTaxonConditionTest extends TestUtils {
         ObjectMapper mapper = new ObjectMapper();
         AndTaxonCondition condition = mapper.readValue(this.resourceReader("and-condition-1.json"), AndTaxonCondition.class);
         TaxonConceptInstance instance = this.createInstance("ID-1", NomenclaturalClassifier.BOTANICAL, "Acacia dealbata", this.provider, TaxonomicType.HOMOTYPIC_SYNONYM);
-        NameKey key = this.analyser.analyse(instance);
+        NameKey key = this.analyser.analyse(instance).getNameKey();
         assertTrue(condition.match(instance, key));
         instance = this.createInstance("ID-1", NomenclaturalClassifier.BOTANICAL, "Acacia dealbata", this.provider, TaxonomicType.ACCEPTED);
-        key = this.analyser.analyse(instance);
+        key = this.analyser.analyse(instance).getNameKey();
         assertFalse(condition.match(instance, key));
     }
 

--- a/ala-name-matching-builder/src/test/java/au/org/ala/names/index/provider/KeyAdjusterTest.java
+++ b/ala-name-matching-builder/src/test/java/au/org/ala/names/index/provider/KeyAdjusterTest.java
@@ -58,7 +58,7 @@ public class KeyAdjusterTest extends TestUtils {
     @Test
     public void testAdjust1() {
         TaxonConceptInstance instance = this.createInstance("ID-1", NomenclaturalClassifier.ZOOLOGICAL, "Osphranter rufus", this.provider, TaxonomicType.ACCEPTED );
-        NameKey key = this.analyser.analyse(instance.getCode(), instance.getScientificName(), instance.getScientificNameAuthorship(), instance.getRank(), null, null, false);
+        NameKey key = this.analyser.analyse(instance.getCode(), instance.getScientificName(), instance.getScientificNameAuthorship(), instance.getRank(), null, null, false).getNameKey();
         NameKey key2 = this.adjuster.adjustKey(key, instance);
         assertSame(key, key2);
     }
@@ -66,7 +66,7 @@ public class KeyAdjusterTest extends TestUtils {
     @Test
     public void testAdjust2() {
         TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalClassifier.BOTANICAL, NomenclaturalClassifier.BOTANICAL.getAcronym(), this.provider,"Acacia dealbata", "Link.", null,null, TaxonomicType.MISAPPLIED, TaxonomicType.MISAPPLIED.getTerm(), RankType.SPECIES,  RankType.SPECIES.getRank(), null, null,null, null, null, null, null, null, null, null, null);
-        NameKey key = this.analyser.analyse(instance.getCode(), instance.getScientificName(), instance.getScientificNameAuthorship(), instance.getRank(), null, null, false);
+        NameKey key = this.analyser.analyse(instance.getCode(), instance.getScientificName(), instance.getScientificNameAuthorship(), instance.getRank(), null, null, false).getNameKey();
         NameKey key2 = this.adjuster.adjustKey(key, instance);
         assertSame(key, key2);
     }
@@ -74,7 +74,7 @@ public class KeyAdjusterTest extends TestUtils {
     @Test
     public void testAdjust3() {
         TaxonConceptInstance instance = this.createInstance("ID-1", NomenclaturalClassifier.VIRUS, "Viruses", this.provider, TaxonomicType.ACCEPTED );
-        NameKey key = this.analyser.analyse(instance.getCode(), instance.getScientificName(), instance.getScientificNameAuthorship(), instance.getRank(), null, null, false);
+        NameKey key = this.analyser.analyse(instance.getCode(), instance.getScientificName(), instance.getScientificNameAuthorship(), instance.getRank(), null, null, false).getNameKey();
         NameKey key2 = this.adjuster.adjustKey(key, instance);
         assertNotSame(key, key2);
         assertEquals(key.getCode(), key2.getCode());
@@ -87,7 +87,7 @@ public class KeyAdjusterTest extends TestUtils {
     @Test
     public void testAdjust4() {
         TaxonConceptInstance instance = this.createInstance("ID-1", NomenclaturalClassifier.find(NomenclaturalCode.PHYLOCODE), "Viruses", this.provider, TaxonomicType.MISAPPLIED );
-        NameKey key = this.analyser.analyse(instance.getCode(), instance.getScientificName(), instance.getScientificNameAuthorship(), instance.getRank(), null, null, false);
+        NameKey key = this.analyser.analyse(instance.getCode(), instance.getScientificName(), instance.getScientificNameAuthorship(), instance.getRank(), null, null, false).getNameKey();
         NameKey key2 = this.adjuster.adjustKey(key, instance);
         assertNotSame(key, key2);
         assertEquals(NomenclaturalClassifier.BACTERIAL, key2.getCode());
@@ -100,7 +100,7 @@ public class KeyAdjusterTest extends TestUtils {
     @Test
     public void testAdjust5() {
         TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalClassifier.find(NomenclaturalCode.PHYLOCODE), NomenclaturalCode.PHYLOCODE.getAcronym(), this.provider,"Acacia dealbata", "Link.", null,null, TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES,  RankType.SPECIES.getRank(), null, null,null, null, null, null, null, null, null, null, null);
-        NameKey key = this.analyser.analyse(instance.getCode(), instance.getScientificName(), instance.getScientificNameAuthorship(), instance.getRank(), null, null, false);
+        NameKey key = this.analyser.analyse(instance.getCode(), instance.getScientificName(), instance.getScientificNameAuthorship(), instance.getRank(), null, null, false).getNameKey();
         NameKey key2 = this.adjuster.adjustKey(key, instance);
         assertNotSame(key, key2);
         assertEquals(NomenclaturalClassifier.BACTERIAL, key2.getCode());
@@ -114,7 +114,7 @@ public class KeyAdjusterTest extends TestUtils {
     @Test
     public void testAdjust6() {
         TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalClassifier.BOTANICAL, NomenclaturalClassifier.BOTANICAL.getAcronym(), this.provider,"Acacia dealbata", "Link.", null,null, TaxonomicType.MISAPPLIED, TaxonomicType.MISAPPLIED.getTerm(), RankType.DOMAIN,  RankType.DOMAIN.getRank(), null, null,null, null, null, null, null, null, null, null, null);
-        NameKey key = this.analyser.analyse(instance.getCode(), instance.getScientificName(), instance.getScientificNameAuthorship(), instance.getRank(), null, null, false);
+        NameKey key = this.analyser.analyse(instance.getCode(), instance.getScientificName(), instance.getScientificNameAuthorship(), instance.getRank(), null, null, false).getNameKey();
         NameKey key2 = this.adjuster.adjustKey(key, instance);
         assertNotSame(key, key2);
         assertEquals(NomenclaturalClassifier.CULTIVARS, key2.getCode());

--- a/ala-name-matching-builder/src/test/java/au/org/ala/names/index/provider/MatchTaxonConditionTest.java
+++ b/ala-name-matching-builder/src/test/java/au/org/ala/names/index/provider/MatchTaxonConditionTest.java
@@ -54,7 +54,7 @@ public class MatchTaxonConditionTest extends TestUtils {
         MatchTaxonCondition condition = new MatchTaxonCondition();
         condition.setNomenclaturalCode(NomenclaturalClassifier.BOTANICAL);
         TaxonConceptInstance instance = this.createInstance("ID-1", NomenclaturalClassifier.BOTANICAL, "Acacia dealbata", this.provider, TaxonomicType.HOMOTYPIC_SYNONYM);
-        NameKey key = this.analyser.analyse(instance);
+        NameKey key = this.analyser.analyse(instance).getNameKey();
         assertTrue(condition.match(instance, key));
     }
 
@@ -63,7 +63,7 @@ public class MatchTaxonConditionTest extends TestUtils {
         MatchTaxonCondition condition = new MatchTaxonCondition();
         condition.setNomenclaturalCode(NomenclaturalClassifier.ZOOLOGICAL);
         TaxonConceptInstance instance = this.createInstance("ID-1", NomenclaturalClassifier.BOTANICAL, "Acacia dealbata", this.provider, TaxonomicType.HOMOTYPIC_SYNONYM);
-        NameKey key = this.analyser.analyse(instance);
+        NameKey key = this.analyser.analyse(instance).getNameKey();
         assertFalse(condition.match(instance, key));
     }
 
@@ -72,7 +72,7 @@ public class MatchTaxonConditionTest extends TestUtils {
         MatchTaxonCondition condition = new MatchTaxonCondition();
         condition.setTaxonomicStatus(TaxonomicType.HOMOTYPIC_SYNONYM);
         TaxonConceptInstance instance = this.createInstance("ID-1", NomenclaturalClassifier.BOTANICAL,  "Acacia dealbata", this.provider, TaxonomicType.HOMOTYPIC_SYNONYM);
-        NameKey key = this.analyser.analyse(instance);
+        NameKey key = this.analyser.analyse(instance).getNameKey();
         assertTrue(condition.match(instance, key));
     }
 
@@ -81,7 +81,7 @@ public class MatchTaxonConditionTest extends TestUtils {
         MatchTaxonCondition condition = new MatchTaxonCondition();
         condition.setTaxonomicStatus(TaxonomicType.ACCEPTED);
         TaxonConceptInstance instance = this.createInstance("ID-1", NomenclaturalClassifier.BOTANICAL, "Acacia dealbata", this.provider, TaxonomicType.HOMOTYPIC_SYNONYM);
-        NameKey key = this.analyser.analyse(instance);
+        NameKey key = this.analyser.analyse(instance).getNameKey();
         assertFalse(condition.match(instance, key));
     }
 
@@ -90,7 +90,7 @@ public class MatchTaxonConditionTest extends TestUtils {
         MatchTaxonCondition condition = new MatchTaxonCondition();
         condition.setNomenclaturalStatus(NomenclaturalStatus.DOUBTFUL);
         TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalClassifier.BOTANICAL, NomenclaturalClassifier.BOTANICAL.getAcronym(), this.provider, "Acacia dealbata", null, null,null, TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), Collections.singleton(NomenclaturalStatus.DOUBTFUL), "doubtful", null, null, null, null, null, null, null, null, null);
-        NameKey key = this.analyser.analyse(instance);
+        NameKey key = this.analyser.analyse(instance).getNameKey();
         assertTrue(condition.match(instance, key));
     }
 
@@ -99,7 +99,7 @@ public class MatchTaxonConditionTest extends TestUtils {
         MatchTaxonCondition condition = new MatchTaxonCondition();
         condition.setNomenclaturalStatus(NomenclaturalStatus.DOUBTFUL);
         TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalClassifier.BOTANICAL, NomenclaturalClassifier.BOTANICAL.getAcronym(), this.provider, "Acacia dealbata", null, null, null, TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(),null, null,null, null, null, null, null, null, null, null, null);
-        NameKey key = this.analyser.analyse(instance);
+        NameKey key = this.analyser.analyse(instance).getNameKey();
         assertFalse(condition.match(instance, key));
     }
 
@@ -108,7 +108,7 @@ public class MatchTaxonConditionTest extends TestUtils {
         MatchTaxonCondition condition = new MatchTaxonCondition();
         condition.setNomenclaturalStatus(NomenclaturalStatus.DOUBTFUL);
         TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalClassifier.BOTANICAL, NomenclaturalClassifier.BOTANICAL.getAcronym(), this.provider, "Acacia dealbata", null, null, null, TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), Collections.singleton(NomenclaturalStatus.ALTERNATIVE), "alternative", null, null, null, null, null, null, null, null, null);
-        NameKey key = this.analyser.analyse(instance);
+        NameKey key = this.analyser.analyse(instance).getNameKey();
         assertFalse(condition.match(instance, key));
     }
 
@@ -117,7 +117,7 @@ public class MatchTaxonConditionTest extends TestUtils {
         MatchTaxonCondition condition = new MatchTaxonCondition();
         condition.setNameType(NameType.SCIENTIFIC);
         TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalClassifier.BOTANICAL, NomenclaturalClassifier.BOTANICAL.getAcronym(), this.provider, "Acacia dealbata", null, null,null, TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null, null);
-        NameKey key = this.analyser.analyse(instance);
+        NameKey key = this.analyser.analyse(instance).getNameKey();
         assertTrue(condition.match(instance, key));
     }
 
@@ -126,7 +126,7 @@ public class MatchTaxonConditionTest extends TestUtils {
         MatchTaxonCondition condition = new MatchTaxonCondition();
         condition.setNameType(NameType.SCIENTIFIC);
         TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalClassifier.BOTANICAL, NomenclaturalClassifier.BOTANICAL.getAcronym(), this.provider, "Acacia unplaced", null, null,null, TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null, null);
-        NameKey key = this.analyser.analyse(instance);
+        NameKey key = this.analyser.analyse(instance).getNameKey();
         assertFalse(condition.match(instance, key));
     }
 
@@ -135,7 +135,7 @@ public class MatchTaxonConditionTest extends TestUtils {
         MatchTaxonCondition condition = new MatchTaxonCondition();
         condition.setTaxonRank(RankType.SPECIES);
         TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalClassifier.BOTANICAL, NomenclaturalClassifier.BOTANICAL.getAcronym(), this.provider, "Acacia dealbata", null, null,null, TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null, null);
-        NameKey key = this.analyser.analyse(instance);
+        NameKey key = this.analyser.analyse(instance).getNameKey();
         assertTrue(condition.match(instance, key));
     }
 
@@ -144,7 +144,7 @@ public class MatchTaxonConditionTest extends TestUtils {
         MatchTaxonCondition condition = new MatchTaxonCondition();
         condition.setTaxonRank(RankType.CLASS);
         TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalClassifier.BOTANICAL, NomenclaturalClassifier.BOTANICAL.getAcronym(), this.provider, "Acacia dealbata", null, null, null, TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null, null);
-        NameKey key = this.analyser.analyse(instance);
+        NameKey key = this.analyser.analyse(instance).getNameKey();
         assertFalse(condition.match(instance, key));
     }
 
@@ -153,7 +153,7 @@ public class MatchTaxonConditionTest extends TestUtils {
         MatchTaxonCondition condition = new MatchTaxonCondition();
         condition.setYear("1974");
         TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalClassifier.BOTANICAL, NomenclaturalClassifier.BOTANICAL.getAcronym(), this.provider, "Acacia dealbata", null, null, "1974", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null, null);
-        NameKey key = this.analyser.analyse(instance);
+        NameKey key = this.analyser.analyse(instance).getNameKey();
         assertTrue(condition.match(instance, key));
     }
 
@@ -162,7 +162,7 @@ public class MatchTaxonConditionTest extends TestUtils {
         MatchTaxonCondition condition = new MatchTaxonCondition();
         condition.setYear("1974");
         TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalClassifier.BOTANICAL, NomenclaturalClassifier.BOTANICAL.getAcronym(), this.provider, "Acacia dealbata", null, null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null, null);
-        NameKey key = this.analyser.analyse(instance);
+        NameKey key = this.analyser.analyse(instance).getNameKey();
         assertFalse(condition.match(instance, key));
     }
 
@@ -171,7 +171,7 @@ public class MatchTaxonConditionTest extends TestUtils {
         MatchTaxonCondition condition = new MatchTaxonCondition();
         condition.setScientificName("Acacia dealbata");
         TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalClassifier.BOTANICAL, NomenclaturalClassifier.BOTANICAL.getAcronym(), this.provider, "Acacia dealbata", null, null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null, null);
-        NameKey key = this.analyser.analyse(instance);
+        NameKey key = this.analyser.analyse(instance).getNameKey();
         assertTrue(condition.match(instance, key));
     }
 
@@ -180,7 +180,7 @@ public class MatchTaxonConditionTest extends TestUtils {
         MatchTaxonCondition condition = new MatchTaxonCondition();
         condition.setScientificName(" Acacia dealbata ");
         TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalClassifier.BOTANICAL, NomenclaturalClassifier.BOTANICAL.getAcronym(), this.provider, "Acacia dealbata", null, null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null, null);
-        NameKey key = this.analyser.analyse(instance);
+        NameKey key = this.analyser.analyse(instance).getNameKey();
         assertTrue(condition.match(instance, key));
     }
 
@@ -189,7 +189,7 @@ public class MatchTaxonConditionTest extends TestUtils {
         MatchTaxonCondition condition = new MatchTaxonCondition();
         condition.setScientificName("Acacia other");
         TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalClassifier.BOTANICAL, NomenclaturalClassifier.BOTANICAL.getAcronym(), this.provider, "Acacia dealbata", null, null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null, null);
-        NameKey key = this.analyser.analyse(instance);
+        NameKey key = this.analyser.analyse(instance).getNameKey();
         assertFalse(condition.match(instance, key));
     }
 
@@ -199,7 +199,7 @@ public class MatchTaxonConditionTest extends TestUtils {
         condition.setScientificName("Acacia dealbata");
         condition.setMatchType(NameMatchType.INSENSITIVE);
         TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalClassifier.BOTANICAL, NomenclaturalClassifier.BOTANICAL.getAcronym(), this.provider, "Acacia dealbata", null, null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null, null);
-        NameKey key = this.analyser.analyse(instance);
+        NameKey key = this.analyser.analyse(instance).getNameKey();
         assertTrue(condition.match(instance, key));
     }
 
@@ -209,7 +209,7 @@ public class MatchTaxonConditionTest extends TestUtils {
         condition.setScientificName(" ACACIA    dealbata ");
         condition.setMatchType(NameMatchType.INSENSITIVE);
         TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalClassifier.BOTANICAL, NomenclaturalClassifier.BOTANICAL.getAcronym(), this.provider, "Acacia dealbata", null, null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null, null);
-        NameKey key = this.analyser.analyse(instance);
+        NameKey key = this.analyser.analyse(instance).getNameKey();
         assertTrue(condition.match(instance, key));
     }
 
@@ -219,7 +219,7 @@ public class MatchTaxonConditionTest extends TestUtils {
         condition.setScientificName(" ACACIA    dealbata ");
         condition.setMatchType(NameMatchType.INSENSITIVE);
         TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalClassifier.BOTANICAL, NomenclaturalClassifier.BOTANICAL.getAcronym(), this.provider, " ACACIA   Dealbata", null, null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null, null);
-        NameKey key = this.analyser.analyse(instance);
+        NameKey key = this.analyser.analyse(instance).getNameKey();
         assertTrue(condition.match(instance, key));
     }
 
@@ -229,7 +229,7 @@ public class MatchTaxonConditionTest extends TestUtils {
         condition.setScientificName("Acacia other");
         condition.setMatchType(NameMatchType.INSENSITIVE);
         TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalClassifier.BOTANICAL, NomenclaturalClassifier.BOTANICAL.getAcronym(), this.provider, "Acacia dealbata", null, null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null, null);
-        NameKey key = this.analyser.analyse(instance);
+        NameKey key = this.analyser.analyse(instance).getNameKey();
         assertFalse(condition.match(instance, key));
     }
 
@@ -239,7 +239,7 @@ public class MatchTaxonConditionTest extends TestUtils {
         condition.setScientificName("Mycofalcella calcarata");
         condition.setMatchType(NameMatchType.NORMALISED);
         TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalClassifier.BOTANICAL, NomenclaturalClassifier.BOTANICAL.getAcronym(), this.provider, "Mycofalcela calcarata", null, null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null, null);
-        NameKey key = this.analyser.analyse(instance);
+        NameKey key = this.analyser.analyse(instance).getNameKey();
         assertTrue(condition.match(instance, key));
     }
 
@@ -249,7 +249,7 @@ public class MatchTaxonConditionTest extends TestUtils {
         condition.setScientificName("Aphanesia greyi");
         condition.setMatchType(NameMatchType.NORMALISED);
         TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalClassifier.BOTANICAL, NomenclaturalClassifier.BOTANICAL.getAcronym(), this.provider, "Aphanesia grei", null, null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null, null);
-        NameKey key = this.analyser.analyse(instance);
+        NameKey key = this.analyser.analyse(instance).getNameKey();
         assertTrue(condition.match(instance, key));
     }
 
@@ -259,7 +259,7 @@ public class MatchTaxonConditionTest extends TestUtils {
         condition.setScientificName("Aphanesia greyi");
         condition.setMatchType(NameMatchType.NORMALISED);
         TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalClassifier.BOTANICAL, NomenclaturalClassifier.BOTANICAL.getAcronym(), this.provider, " Aphanesia  greyi  ", null, null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null, null);
-        NameKey key = this.analyser.analyse(instance);
+        NameKey key = this.analyser.analyse(instance).getNameKey();
         assertTrue(condition.match(instance, key));
     }
 
@@ -269,7 +269,7 @@ public class MatchTaxonConditionTest extends TestUtils {
         condition.setScientificName("Aphanesia greyi");
         condition.setMatchType(NameMatchType.NORMALISED);
         TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalClassifier.BOTANICAL, NomenclaturalClassifier.BOTANICAL.getAcronym(), this.provider, "Acacia dealbata", null, null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null, null);
-        NameKey key = this.analyser.analyse(instance);
+        NameKey key = this.analyser.analyse(instance).getNameKey();
         assertFalse(condition.match(instance, key));
     }
 
@@ -280,10 +280,10 @@ public class MatchTaxonConditionTest extends TestUtils {
         condition.setScientificName("Mycofalcel+a calca?rata");
         condition.setMatchType(NameMatchType.REGEX);
         TaxonConceptInstance instance1 = new TaxonConceptInstance("ID-1", NomenclaturalClassifier.BOTANICAL, NomenclaturalClassifier.BOTANICAL.getAcronym(), this.provider, "Mycofalcella calcarata", null, null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null, null);
-        NameKey key1 = this.analyser.analyse(instance1);
+        NameKey key1 = this.analyser.analyse(instance1).getNameKey();
         assertTrue(condition.match(instance1, key1));
         TaxonConceptInstance instance2 = new TaxonConceptInstance("ID-1", NomenclaturalClassifier.BOTANICAL, NomenclaturalClassifier.BOTANICAL.getAcronym(), this.provider, "Mycofalcela calcrata", null, null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null, null);
-        NameKey key2 = this.analyser.analyse(instance2);
+        NameKey key2 = this.analyser.analyse(instance2).getNameKey();
         assertTrue(condition.match(instance2, key2));
     }
 
@@ -293,7 +293,7 @@ public class MatchTaxonConditionTest extends TestUtils {
         condition.setScientificName("Aphanesia gr[eyi]+");
         condition.setMatchType(NameMatchType.REGEX);
         TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalClassifier.BOTANICAL, NomenclaturalClassifier.BOTANICAL.getAcronym(), this.provider, "Aphanesia greyi", null, null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null, null);
-        NameKey key = this.analyser.analyse(instance);
+        NameKey key = this.analyser.analyse(instance).getNameKey();
         assertTrue(condition.match(instance, key));
     }
 
@@ -303,7 +303,7 @@ public class MatchTaxonConditionTest extends TestUtils {
         condition.setScientificName("Aphanesia gr[eyi]+");
         condition.setMatchType(NameMatchType.REGEX);
         TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalClassifier.BOTANICAL, NomenclaturalClassifier.BOTANICAL.getAcronym(), this.provider, "Acacia dealbata", null, null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null, null);
-        NameKey key = this.analyser.analyse(instance);
+        NameKey key = this.analyser.analyse(instance).getNameKey();
         assertFalse(condition.match(instance, key));
     }
 
@@ -314,7 +314,7 @@ public class MatchTaxonConditionTest extends TestUtils {
         condition.setScientificNameAuthorship("Benth.");
         condition.setMatchType(NameMatchType.EXACT);
         TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalClassifier.BOTANICAL, NomenclaturalClassifier.BOTANICAL.getAcronym(), this.provider, "Lepidosperma leptophyllum", "Benth.", null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null, null);
-        NameKey key = this.analyser.analyse(instance);
+        NameKey key = this.analyser.analyse(instance).getNameKey();
         assertTrue(condition.match(instance, key));
     }
 
@@ -324,7 +324,7 @@ public class MatchTaxonConditionTest extends TestUtils {
         condition.setScientificNameAuthorship("Benth.");
         condition.setMatchType(NameMatchType.EXACT);
         TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalClassifier.BOTANICAL, NomenclaturalClassifier.BOTANICAL.getAcronym(), this.provider, "Lepidosperma leptophyllum", " Benth.", null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null, null);
-        NameKey key = this.analyser.analyse(instance);
+        NameKey key = this.analyser.analyse(instance).getNameKey();
         assertTrue(condition.match(instance, key));
     }
 
@@ -334,7 +334,7 @@ public class MatchTaxonConditionTest extends TestUtils {
         condition.setScientificNameAuthorship("Benth.");
         condition.setMatchType(NameMatchType.EXACT);
         TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalClassifier.BOTANICAL, NomenclaturalClassifier.BOTANICAL.getAcronym(), this.provider, "Lepidosperma leptophyllum", "Bentham", null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null, null);
-        NameKey key = this.analyser.analyse(instance);
+        NameKey key = this.analyser.analyse(instance).getNameKey();
         assertFalse(condition.match(instance, key));
     }
 
@@ -345,7 +345,7 @@ public class MatchTaxonConditionTest extends TestUtils {
         condition.setScientificNameAuthorship("Benth.");
         condition.setMatchType(NameMatchType.INSENSITIVE);
         TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalClassifier.BOTANICAL, NomenclaturalClassifier.BOTANICAL.getAcronym(), this.provider, "Lepidosperma leptophyllum", "Benth.", null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null, null);
-        NameKey key = this.analyser.analyse(instance);
+        NameKey key = this.analyser.analyse(instance).getNameKey();
         assertTrue(condition.match(instance, key));
     }
 
@@ -355,7 +355,7 @@ public class MatchTaxonConditionTest extends TestUtils {
         condition.setScientificNameAuthorship("Benth.");
         condition.setMatchType(NameMatchType.INSENSITIVE);
         TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalClassifier.BOTANICAL, NomenclaturalClassifier.BOTANICAL.getAcronym(), this.provider, "Lepidosperma leptophyllum", " BENTh.", null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null, null);
-        NameKey key = this.analyser.analyse(instance);
+        NameKey key = this.analyser.analyse(instance).getNameKey();
         assertTrue(condition.match(instance, key));
     }
 
@@ -365,7 +365,7 @@ public class MatchTaxonConditionTest extends TestUtils {
         condition.setScientificNameAuthorship("Benth.");
         condition.setMatchType(NameMatchType.INSENSITIVE);
         TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalClassifier.BOTANICAL, NomenclaturalClassifier.BOTANICAL.getAcronym(), this.provider, "Lepidosperma leptophyllum", "Bentham", null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null, null);
-        NameKey key = this.analyser.analyse(instance);
+        NameKey key = this.analyser.analyse(instance).getNameKey();
         assertFalse(condition.match(instance, key));
     }
 
@@ -375,7 +375,7 @@ public class MatchTaxonConditionTest extends TestUtils {
         condition.setScientificNameAuthorship("Benth.");
         condition.setMatchType(NameMatchType.NORMALISED);
         TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalClassifier.BOTANICAL, NomenclaturalClassifier.BOTANICAL.getAcronym(), this.provider, "Lepidosperma leptophyllum", "Benth.", null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null, null);
-        NameKey key = this.analyser.analyse(instance);
+        NameKey key = this.analyser.analyse(instance).getNameKey();
         assertTrue(condition.match(instance, key));
     }
 
@@ -385,7 +385,7 @@ public class MatchTaxonConditionTest extends TestUtils {
         condition.setScientificNameAuthorship("Benth.");
         condition.setMatchType(NameMatchType.NORMALISED);
         TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalClassifier.BOTANICAL, NomenclaturalClassifier.BOTANICAL.getAcronym(), this.provider, "Lepidosperma leptophyllum", "Bentham", null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null, null);
-        NameKey key = this.analyser.analyse(instance);
+        NameKey key = this.analyser.analyse(instance).getNameKey();
         assertTrue(condition.match(instance, key));
     }
 
@@ -395,7 +395,7 @@ public class MatchTaxonConditionTest extends TestUtils {
         condition.setScientificNameAuthorship("Benth.");
         condition.setMatchType(NameMatchType.NORMALISED);
         TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalClassifier.BOTANICAL, NomenclaturalClassifier.BOTANICAL.getAcronym(), this.provider, "Lepidosperma leptophyllum", "L.", null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null, null);
-        NameKey key = this.analyser.analyse(instance);
+        NameKey key = this.analyser.analyse(instance).getNameKey();
         assertFalse(condition.match(instance, key));
     }
 
@@ -405,10 +405,10 @@ public class MatchTaxonConditionTest extends TestUtils {
         condition.setScientificNameAuthorship("Benth\\.?");
         condition.setMatchType(NameMatchType.REGEX);
         TaxonConceptInstance instance1 = new TaxonConceptInstance("ID-1", NomenclaturalClassifier.BOTANICAL, NomenclaturalClassifier.BOTANICAL.getAcronym(), this.provider, "Lepidosperma leptophyllum", "Benth.", null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null, null);
-        NameKey key1 = this.analyser.analyse(instance1);
+        NameKey key1 = this.analyser.analyse(instance1).getNameKey();
         assertTrue(condition.match(instance1, key1));
         TaxonConceptInstance instance2 = new TaxonConceptInstance("ID-1", NomenclaturalClassifier.BOTANICAL, NomenclaturalClassifier.BOTANICAL.getAcronym(), this.provider, "Lepidosperma leptophyllum", "Benth", null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null, null);
-        NameKey key2 = this.analyser.analyse(instance2);
+        NameKey key2 = this.analyser.analyse(instance2).getNameKey();
         assertTrue(condition.match(instance2, key2));
     }
 
@@ -418,13 +418,13 @@ public class MatchTaxonConditionTest extends TestUtils {
         condition.setScientificNameAuthorship("[Bb]enth(am|\\.)?");
         condition.setMatchType(NameMatchType.REGEX);
         TaxonConceptInstance instance1 = new TaxonConceptInstance("ID-1", NomenclaturalClassifier.BOTANICAL, NomenclaturalClassifier.BOTANICAL.getAcronym(), this.provider, "Lepidosperma leptophyllum", "Benth", null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null, null);
-        NameKey key1 = this.analyser.analyse(instance1);
+        NameKey key1 = this.analyser.analyse(instance1).getNameKey();
         assertTrue(condition.match(instance1, key1));
         TaxonConceptInstance instance2 = new TaxonConceptInstance("ID-1", NomenclaturalClassifier.BOTANICAL, NomenclaturalClassifier.BOTANICAL.getAcronym(), this.provider, "Lepidosperma leptophyllum", "bentham", null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null, null);
-        NameKey key2 = this.analyser.analyse(instance2);
+        NameKey key2 = this.analyser.analyse(instance2).getNameKey();
         assertTrue(condition.match(instance2, key2));
         TaxonConceptInstance instance3 = new TaxonConceptInstance("ID-1", NomenclaturalClassifier.BOTANICAL, NomenclaturalClassifier.BOTANICAL.getAcronym(), this.provider, "Lepidosperma leptophyllum", "Benth.", null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null, null);
-        NameKey key3 = this.analyser.analyse(instance3);
+        NameKey key3 = this.analyser.analyse(instance3).getNameKey();
         assertTrue(condition.match(instance3, key3));
     }
 
@@ -434,7 +434,7 @@ public class MatchTaxonConditionTest extends TestUtils {
         condition.setScientificNameAuthorship("[Bb]enth(am|\\.)?");
         condition.setMatchType(NameMatchType.REGEX);
         TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalClassifier.BOTANICAL, NomenclaturalClassifier.BOTANICAL.getAcronym(), this.provider, "Lepidosperma leptophyllum", "Benthos", null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null, null);
-        NameKey key = this.analyser.analyse(instance);
+        NameKey key = this.analyser.analyse(instance).getNameKey();
         assertFalse(condition.match(instance, key));
     }
 
@@ -443,7 +443,7 @@ public class MatchTaxonConditionTest extends TestUtils {
         MatchTaxonCondition condition = new MatchTaxonCondition();
         condition.setDatasetID(this.provider.getId());
         TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalClassifier.BOTANICAL, NomenclaturalClassifier.BOTANICAL.getAcronym(), this.provider, "Lepidosperma leptophyllum", "Benth.", null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null, null);
-        NameKey key = this.analyser.analyse(instance);
+        NameKey key = this.analyser.analyse(instance).getNameKey();
         assertTrue(condition.match(instance, key));
     }
 
@@ -452,7 +452,7 @@ public class MatchTaxonConditionTest extends TestUtils {
         MatchTaxonCondition condition = new MatchTaxonCondition();
         condition.setDatasetID("other");
         TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalClassifier.BOTANICAL, NomenclaturalClassifier.BOTANICAL.getAcronym(), this.provider, "Lepidosperma leptophyllum", "Benth.", null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null, null);
-        NameKey key = this.analyser.analyse(instance);
+        NameKey key = this.analyser.analyse(instance).getNameKey();
         assertFalse(condition.match(instance, key));
     }
 
@@ -463,13 +463,13 @@ public class MatchTaxonConditionTest extends TestUtils {
         condition.setScientificName("Unknown(\\s.*|)");
         condition.setMatchType(NameMatchType.REGEX);
         TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalClassifier.BOTANICAL, NomenclaturalClassifier.BOTANICAL.getAcronym(), this.provider, "unknown", null, null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null, null);
-        NameKey key = this.analyser.analyse(instance);
+        NameKey key = this.analyser.analyse(instance).getNameKey();
         assertTrue(condition.match(instance, key));
         instance = new TaxonConceptInstance("ID-1", NomenclaturalClassifier.BOTANICAL, NomenclaturalClassifier.BOTANICAL.getAcronym(), this.provider, "Unknown sp.", null, null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null, null);
-        key = this.analyser.analyse(instance);
+        key = this.analyser.analyse(instance).getNameKey();
         assertTrue(condition.match(instance, key));
         instance = new TaxonConceptInstance("ID-1", NomenclaturalClassifier.BOTANICAL, NomenclaturalClassifier.BOTANICAL.getAcronym(), this.provider, "Unknownsp.", null, null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null, null);
-        key = this.analyser.analyse(instance);
+        key = this.analyser.analyse(instance).getNameKey();
         assertFalse(condition.match(instance, key));
     }
 
@@ -480,13 +480,13 @@ public class MatchTaxonConditionTest extends TestUtils {
         MatchTaxonCondition condition = new MatchTaxonCondition();
         condition.setTaxonomicFlag(TaxonFlag.AMBIGUOUS_NOMENCLATURAL_CODE);
         TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalClassifier.BOTANICAL, NomenclaturalClassifier.BOTANICAL.getAcronym(), this.provider, "unknown", null, null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null, null);
-        NameKey key = this.analyser.analyse(instance);
+        NameKey key = this.analyser.analyse(instance).getNameKey();
         assertFalse(condition.match(instance, key));
         instance = new TaxonConceptInstance("ID-1", NomenclaturalClassifier.BOTANICAL, NomenclaturalClassifier.BOTANICAL.getAcronym(), this.provider, "Unknown sp.", null, null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null, Collections.singleton(TaxonFlag.AUTONYM));
-        key = this.analyser.analyse(instance);
+        key = this.analyser.analyse(instance).getNameKey();
         assertFalse(condition.match(instance, key));
         instance = new TaxonConceptInstance("ID-1", NomenclaturalClassifier.BOTANICAL, NomenclaturalClassifier.BOTANICAL.getAcronym(), this.provider, "Unknownsp.", null, null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null, Collections.singleton(TaxonFlag.AMBIGUOUS_NOMENCLATURAL_CODE));
-        key = this.analyser.analyse(instance);
+        key = this.analyser.analyse(instance).getNameKey();
         assertTrue(condition.match(instance, key));
     }
 
@@ -507,10 +507,10 @@ public class MatchTaxonConditionTest extends TestUtils {
         ObjectMapper mapper = new ObjectMapper();
         MatchTaxonCondition condition = mapper.readValue(this.resourceReader("match-condition-1.json"), MatchTaxonCondition.class);
         TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalClassifier.BOTANICAL, NomenclaturalClassifier.BOTANICAL.getAcronym(), this.provider, "Acacia dealbata", null, null, "1975", TaxonomicType.EXCLUDED, TaxonomicType.EXCLUDED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null, null);
-        NameKey key = this.analyser.analyse(instance);
+        NameKey key = this.analyser.analyse(instance).getNameKey();
         assertTrue(condition.match(instance, key));
         instance = new TaxonConceptInstance("ID-1", NomenclaturalClassifier.BOTANICAL, NomenclaturalClassifier.BOTANICAL.getAcronym(), this.provider, "Acacia dealbata", null, null, "1975", TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.SPECIES, RankType.SPECIES.getRank(), null, null, null, null, null, null, null, null, null, null, null);
-        key = this.analyser.analyse(instance);
+        key = this.analyser.analyse(instance).getNameKey();
         assertFalse(condition.match(instance, key));
     }
 

--- a/ala-name-matching-builder/src/test/java/au/org/ala/names/index/provider/OrTaxonConditionTest.java
+++ b/ala-name-matching-builder/src/test/java/au/org/ala/names/index/provider/OrTaxonConditionTest.java
@@ -51,7 +51,7 @@ public class OrTaxonConditionTest extends TestUtils {
         condition1.setNomenclaturalCode(NomenclaturalClassifier.BOTANICAL);
         condition.add(condition1);
         TaxonConceptInstance instance = this.createInstance("ID-1", NomenclaturalClassifier.BOTANICAL, "Acacia dealbata", this.provider, TaxonomicType.HOMOTYPIC_SYNONYM);
-        NameKey key = this.analyser.analyse(instance);
+        NameKey key = this.analyser.analyse(instance).getNameKey();
         assertTrue(condition.match(instance, key));
     }
 
@@ -62,7 +62,7 @@ public class OrTaxonConditionTest extends TestUtils {
         condition1.setNomenclaturalCode(NomenclaturalClassifier.ZOOLOGICAL);
         condition.add(condition1);
         TaxonConceptInstance instance = this.createInstance("ID-1", NomenclaturalClassifier.BOTANICAL, "Acacia dealbata", this.provider, TaxonomicType.HOMOTYPIC_SYNONYM);
-        NameKey key = this.analyser.analyse(instance);
+        NameKey key = this.analyser.analyse(instance).getNameKey();
         assertFalse(condition.match(instance, key));
     }
 
@@ -77,7 +77,7 @@ public class OrTaxonConditionTest extends TestUtils {
         condition.add(condition1);
         condition.add(condition2);
         TaxonConceptInstance instance = this.createInstance("ID-1", NomenclaturalClassifier.BOTANICAL, "Acacia dealbata", this.provider, TaxonomicType.HOMOTYPIC_SYNONYM);
-        NameKey key = this.analyser.analyse(instance);
+        NameKey key = this.analyser.analyse(instance).getNameKey();
         assertTrue(condition.match(instance, key));
     }
 
@@ -91,7 +91,7 @@ public class OrTaxonConditionTest extends TestUtils {
         condition.add(condition1);
         condition.add(condition2);
         TaxonConceptInstance instance = this.createInstance("ID-1", NomenclaturalClassifier.ZOOLOGICAL, "Acacia dealbata", this.provider, TaxonomicType.HOMOTYPIC_SYNONYM);
-        NameKey key = this.analyser.analyse(instance);
+        NameKey key = this.analyser.analyse(instance).getNameKey();
         assertTrue(condition.match(instance, key));
     }
 
@@ -105,7 +105,7 @@ public class OrTaxonConditionTest extends TestUtils {
         condition.add(condition1);
         condition.add(condition2);
         TaxonConceptInstance instance = this.createInstance("ID-1", NomenclaturalClassifier.BOTANICAL, "Acacia dealbata", this.provider, TaxonomicType.ACCEPTED);
-        NameKey key = this.analyser.analyse(instance);
+        NameKey key = this.analyser.analyse(instance).getNameKey();
         assertTrue(condition.match(instance, key));
     }
 
@@ -119,7 +119,7 @@ public class OrTaxonConditionTest extends TestUtils {
         condition.add(condition1);
         condition.add(condition2);
         TaxonConceptInstance instance = this.createInstance("ID-1", NomenclaturalClassifier.ZOOLOGICAL, "Acacia dealbata", this.provider, TaxonomicType.ACCEPTED);
-        NameKey key = this.analyser.analyse(instance);
+        NameKey key = this.analyser.analyse(instance).getNameKey();
         assertFalse(condition.match(instance, key));
     }
 
@@ -144,13 +144,13 @@ public class OrTaxonConditionTest extends TestUtils {
         ObjectMapper mapper = new ObjectMapper();
         OrTaxonCondition condition = mapper.readValue(this.resourceReader("or-condition-1.json"), OrTaxonCondition.class);
         TaxonConceptInstance instance = this.createInstance("ID-1", NomenclaturalClassifier.BOTANICAL, "Acacia dealbata", this.provider, TaxonomicType.HOMOTYPIC_SYNONYM);
-        NameKey key = this.analyser.analyse(instance);
+        NameKey key = this.analyser.analyse(instance).getNameKey();
         assertTrue(condition.match(instance, key));
         instance = this.createInstance("ID-1", NomenclaturalClassifier.BOTANICAL, "Acacia dealbata", this.provider, TaxonomicType.ACCEPTED);
-        key = this.analyser.analyse(instance);
+        key = this.analyser.analyse(instance).getNameKey();
         assertTrue(condition.match(instance, key));
         instance = this.createInstance("ID-1", NomenclaturalClassifier.ZOOLOGICAL, "Acacia dealbata", this.provider, TaxonomicType.ACCEPTED);
-        key = this.analyser.analyse(instance);
+        key = this.analyser.analyse(instance).getNameKey();
         assertFalse(condition.match(instance, key));
     }
 

--- a/ala-name-matching-builder/src/test/java/au/org/ala/names/index/provider/ScoreAdjusterTest.java
+++ b/ala-name-matching-builder/src/test/java/au/org/ala/names/index/provider/ScoreAdjusterTest.java
@@ -56,7 +56,7 @@ public class ScoreAdjusterTest extends TestUtils {
     @Test
     public void testForbidden1() {
         TaxonConceptInstance instance = this.createInstance("ID-1", NomenclaturalClassifier.ZOOLOGICAL, "Osphranter rufus", this.provider, TaxonomicType.ACCEPTED );
-        NameKey key = this.analyser.analyse(instance);
+        NameKey key = this.analyser.analyse(instance).getNameKey();
         assertNull(adjuster.forbid(instance, key));
     }
 
@@ -64,49 +64,49 @@ public class ScoreAdjusterTest extends TestUtils {
     @Test
     public void testForbidden2() {
         TaxonConceptInstance instance = this.createInstance("ID-1", NomenclaturalClassifier.ZOOLOGICAL, "Osphranter rufus", this.provider, TaxonomicType.INCERTAE_SEDIS );
-        NameKey key = this.analyser.analyse(instance);
+        NameKey key = this.analyser.analyse(instance).getNameKey();
         assertEquals("taxonomicStatus:INCERTAE_SEDIS", adjuster.forbid(instance, key));
     }
 
     @Test
     public void testScore1() {
         TaxonConceptInstance instance = this.createInstance("ID-1", NomenclaturalClassifier.ZOOLOGICAL, "Osphranter rufus", this.provider, TaxonomicType.ACCEPTED );
-        NameKey key = this.analyser.analyse(instance);
+        NameKey key = this.analyser.analyse(instance).getNameKey();
         assertEquals(0, adjuster.score(0, instance, key));
     }
 
     @Test
     public void testScore2() {
         TaxonConceptInstance instance = this.createInstance("ID-1", NomenclaturalClassifier.ZOOLOGICAL, "Osphranter rufus", this.provider, TaxonomicType.ACCEPTED );
-        NameKey key = this.analyser.analyse(instance);
+        NameKey key = this.analyser.analyse(instance).getNameKey();
         assertEquals(50, adjuster.score(50, instance, key));
     }
 
     @Test
     public void testScore3() {
         TaxonConceptInstance instance = this.createInstance("ID-1", NomenclaturalClassifier.ZOOLOGICAL, "Osphranter rufus", this.provider, TaxonomicType.MISAPPLIED );
-        NameKey key = this.analyser.analyse(instance);
+        NameKey key = this.analyser.analyse(instance).getNameKey();
         assertEquals(-10, adjuster.score(0, instance, key));
     }
 
     @Test
     public void testScore4() {
         TaxonConceptInstance instance = this.createInstance("ID-1", NomenclaturalClassifier.ZOOLOGICAL, "Osphranter rufus", this.provider, TaxonomicType.MISAPPLIED );
-        NameKey key = this.analyser.analyse(instance);
+        NameKey key = this.analyser.analyse(instance).getNameKey();
         assertEquals(90, adjuster.score(100, instance, key));
     }
 
     @Test
     public void testScore5() {
         TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalClassifier.BOTANICAL, NomenclaturalClassifier.BOTANICAL.getAcronym(), this.provider,"Acacia dealbata", "Link.", null, null, TaxonomicType.ACCEPTED, TaxonomicType.ACCEPTED.getTerm(), RankType.DOMAIN,  RankType.DOMAIN.getRank(), null, null,null, null, null, null, null, null, null, null, null);
-        NameKey key = this.analyser.analyse(instance);
+        NameKey key = this.analyser.analyse(instance).getNameKey();
         assertEquals(115, adjuster.score(100, instance, key));
     }
 
     @Test
     public void testScore6() {
         TaxonConceptInstance instance = new TaxonConceptInstance("ID-1", NomenclaturalClassifier.BOTANICAL, NomenclaturalClassifier.BOTANICAL.getAcronym(), this.provider,"Acacia dealbata", "Link.", null, null, TaxonomicType.MISAPPLIED, TaxonomicType.MISAPPLIED.getTerm(), RankType.DOMAIN,  RankType.DOMAIN.getRank(), null, null,null, null, null, null, null, null, null, null, null);
-        NameKey key = this.analyser.analyse(instance);
+        NameKey key = this.analyser.analyse(instance).getNameKey();
         assertEquals(105, adjuster.score(100, instance, key));
     }
 }

--- a/ala-name-matching-builder/src/test/resources/au/org/ala/names/index/taxonomy-27.csv
+++ b/ala-name-matching-builder/src/test/resources/au/org/ala/names/index/taxonomy-27.csv
@@ -1,4 +1,5 @@
 taxonID,parentNameUsageID,acceptedNameUsageID,datasetID,nomenclaturalCode,scientificName,scientificNameAuthorship,taxonRank,taxonConceptID,scientificNameID,taxonomicStatus,nomenclaturalStatus,establishmentMeans,nameAccordingToID,nameAccordingTo,namePublishedInID,namePublishedIn,namePubishedInYear,nameComplete,nameFormatted,source
+"Genus-1","","","dr107","ICN","Myosurus","L.","genus","","","accepted","","","","","","","","","",""
 "Accepted-1","","","dr107","ICN","Myosurus minimus","L.","species","","","accepted","","","","","","","","","",""
 "Accepted-2","","","dr100","ICN","Myosurus australis","F.Muell.","species","","","accepted","","","","","","","","","",""
 "Synonym-1","","Accepted-2","dr100","ICBN","Myosurus minimus","L.","species","","","misapplied","","","","","","","","","",""

--- a/ala-name-matching-builder/src/test/resources/au/org/ala/names/index/taxonomy-28.csv
+++ b/ala-name-matching-builder/src/test/resources/au/org/ala/names/index/taxonomy-28.csv
@@ -1,4 +1,8 @@
 taxonID,parentNameUsageID,acceptedNameUsageID,datasetID,nomenclaturalCode,scientificName,scientificNameAuthorship,taxonRank,taxonConceptID,scientificNameID,taxonomicStatus,nomenclaturalStatus,establishmentMeans,nameAccordingToID,nameAccordingTo,namePublishedInID,namePublishedIn,namePubishedInYear,nameComplete,nameFormatted,source
+"Genus-1","","","dr100","ICN","Gonocarpus","","genus","","","accepted","","","","","","","","","",""
+"Genus-2","","","dr100","ICN","Senecio","","genus","","","accepted","","","","","","","","","",""
+"Species-1","","","dr100","ICN","Gonocarpus micranthus","","species","","","accepted","","","","","","","","","",""
+"Species-2","","","dr100","ICN","Senecio glomeratus","","species","","","accepted","","","","","","","","","",""
 "Autonym-1-1","","","dr100","ICN","Gonocarpus micranthus subsp. micranthus","","subspecies","","","accepted","","","","","","","","Gonocarpus micranthus Thunb. subsp. micranthus","",""
 "Autonym-1-2","","","dr101","ICN","Gonocarpus micranthus subsp. micranthus","Thunb.","subspecies","","","accepted","","","","","","","","Gonocarpus micranthus Thunb. subsp. micranthus","",""
 "Autonym-2-1","","","dr100","ICN","Senecio glomeratus subsp. glomeratus","","subspecies","","","accepted","","","","","","","","Senecio glomeratus Desf. ex Poir. subsp. glomeratus","",""

--- a/ala-name-matching-builder/src/test/resources/au/org/ala/names/index/taxonomy-31.csv
+++ b/ala-name-matching-builder/src/test/resources/au/org/ala/names/index/taxonomy-31.csv
@@ -1,4 +1,5 @@
 taxonID,parentNameUsageID,acceptedNameUsageID,datasetID,nomenclaturalCode,scientificName,scientificNameAuthorship,taxonRank,taxonConceptID,scientificNameID,taxonomicStatus,nomenclaturalStatus,establishmentMeans,nameAccordingToID,nameAccordingTo,namePublishedInID,namePublishedIn,namePubishedInYear,nameComplete,nameFormatted,source
+"Genus-1","","","dr115","ICN","Carmichaelia",".","genus","","","accepted","","","","","","","","Carmichaelia","",""
 "Concept-1-1","","","dr115","ICN","Carmichaelia cunninghamii","Raoul ex Lehm.","species","","","accepted","","","","","","","","Carmichaelia cunninghamii Raoul ex Lehm.","",""
 "Concept-1-2","","Concept-2-1","dr116","ICN","Carmichaelia cunninghamii","Raoul ex Lehm.","species","","","synonym","","","","","","","","Carmichaelia cunninghamii Raoul ex Lehm.","",""
 "Concept-1-3","","Concept-3-1","dr100","ICN","Carmichaelia cunninghamii","Raoul ex Lehm.","species","","","synonym","","","","","","","","Carmichaelia cunninghamii Raoul ex Lehm.","",""

--- a/ala-name-matching-search/src/test/java/au/org/ala/names/search/ALANameSearcherTest.java
+++ b/ala-name-matching-search/src/test/java/au/org/ala/names/search/ALANameSearcherTest.java
@@ -906,13 +906,40 @@ public class ALANameSearcherTest {
         }
     }
 
-    @Ignore // TODO No additional reallsid currently used
     @Test
-    public void testGetPrimaryLsid() {
+    public void testGetPrimaryLsid1() {
         String primaryLsid = searcher.getPrimaryLsid("https://id.biodiversity.org.au/node/apni/2889838");
         assertEquals("https://id.biodiversity.org.au/node/apni/2889838", primaryLsid);
-        primaryLsid = searcher.getPrimaryLsid("https://id.biodiversity.org.au/instance/apni/887198");
-        assertEquals("https://id.biodiversity.org.au/node/apni/5487102", primaryLsid);
+    }
+
+    @Test
+    public void testGetPrimaryLsid2() {
+        String primaryLsid = searcher.getPrimaryLsid("http://id.biodiversity.org.au/node/apni/2890752");
+        assertEquals("https://id.biodiversity.org.au/node/apni/2890752", primaryLsid);
+    }
+
+    @Test
+    public void testGetPrimaryLsid3() {
+        String primaryLsid = searcher.getPrimaryLsid("https://id.biodiversity.org.au/instance/apni/707711");
+        assertEquals("https://id.biodiversity.org.au/node/apni/2890752", primaryLsid);
+    }
+
+    @Test
+    public void testGetPrimaryLsid4() {
+        String primaryLsid = searcher.getPrimaryLsid("ALA_3624216");
+        assertEquals("https://id.biodiversity.org.au/node/apni/2890752", primaryLsid);
+    }
+
+    @Test
+    public void testGetPrimaryLsid5() {
+        String primaryLsid = searcher.getPrimaryLsid("urn:lsid:biodiversity.org.au:afd.taxon:f71a4c71-48e1-4a9f-840e-1bb189611fd4");
+        assertEquals("https://biodiversity.org.au/afd/taxa/f71a4c71-48e1-4a9f-840e-1bb189611fd4", primaryLsid);
+    }
+
+    @Test
+    public void testGetPrimaryLsid6() {
+        String primaryLsid = searcher.getPrimaryLsid("http://biodiversity.org.au/afd/taxa/f71a4c71-48e1-4a9f-840e-1bb189611fd4");
+        assertEquals("https://biodiversity.org.au/afd/taxa/f71a4c71-48e1-4a9f-840e-1bb189611fd4", primaryLsid);
     }
 
     @Test
@@ -1126,7 +1153,6 @@ public class ALANameSearcherTest {
         String sciName = getCommonName(name);
         assertEquals("Cacatua (Cacatua) galerita", sciName);
     }
-
     private String getCommonNameLSID(String name) {
         return searcher.searchForLSIDCommonName(name);
     }

--- a/ala-name-matching-search/src/test/java/au/org/ala/names/search/ALANameSearcherTest.java
+++ b/ala-name-matching-search/src/test/java/au/org/ala/names/search/ALANameSearcherTest.java
@@ -20,6 +20,7 @@ package au.org.ala.names.search;
 
 import au.org.ala.names.model.*;
 import org.gbif.api.model.checklistbank.ParsedName;
+import org.gbif.api.vocabulary.NameType;
 import org.gbif.nameparser.PhraseNameParser;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -1875,6 +1876,21 @@ public class ALANameSearcherTest {
         assertTrue(metrics.getErrors().contains(ErrorType.MATCH_MISAPPLIED));
     }
 
+    // Available as a synonym but also misapplied.
+    @Test
+    public void testSynonymMisapplied2() throws Exception {
+        String name = "Rulingia rugosa";
+        LinnaeanRankClassification cl = new LinnaeanRankClassification();
+        cl.setScientificName(name);
+        MetricsResultDTO metrics = searcher.searchForRecordMetrics(cl, true);
+        assertNotNull(metrics);
+        assertEquals(SynonymType.OBJECTIVE_SYNONYM, metrics.getResult().getSynonymType());
+        assertEquals("https://id.biodiversity.org.au/instance/apni/949024", metrics.getResult().getLsid());
+        assertEquals("https://id.biodiversity.org.au/node/apni/2891679", metrics.getResult().getAcceptedLsid());
+        assertEquals(MatchType.EXACT, metrics.getResult().getMatchType());
+        assertTrue(metrics.getErrors().contains(ErrorType.MATCH_MISAPPLIED));
+    }
+
 
     // Higher taxonomy only filled out
     @Test
@@ -1981,7 +1997,6 @@ public class ALANameSearcherTest {
         assertEquals(SynonymType.OBJECTIVE_SYNONYM, metrics.getResult().getSynonymType());
     }
 
-
     // Ensure illegitimate names are excluded from the system and don't gum the works up
     @Test
     public void testIllegitimate2() throws Exception {
@@ -1993,6 +2008,33 @@ public class ALANameSearcherTest {
         assertEquals("https://id.biodiversity.org.au/name/apni/51337126", metrics.getResult().getLsid());
         assertEquals("https://id.biodiversity.org.au/taxon/apni/51367864", metrics.getResult().getRankClassification().getGid());
         assertEquals("https://id.biodiversity.org.au/taxon/apni/51367862", metrics.getResult().getRankClassification().getFid());
+        assertEquals(MatchType.EXACT, metrics.getResult().getMatchType());
+    }
+
+
+    // Test vile examples where someone has put in something like Genus N27 or Genus B
+    @Test
+    public void testGenusMarker1() throws Exception {
+        String name = "Genus NC72";
+        LinnaeanRankClassification cl = new LinnaeanRankClassification();
+        cl.setScientificName(name);
+        MetricsResultDTO metrics = searcher.searchForRecordMetrics(cl, true);
+        assertNotNull(metrics);
+        assertEquals(NameType.INFORMAL, metrics.getNameType());
+        assertNull(metrics.getResult());
+    }
+
+
+    // Test vile examples where someone has put in something like Genus N27 or Genus B
+    @Test
+    public void testGenusMarker2() throws Exception {
+        String name = "Genus B";
+        LinnaeanRankClassification cl = new LinnaeanRankClassification();
+        cl.setScientificName(name);
+        MetricsResultDTO metrics = searcher.searchForRecordMetrics(cl, true);
+        assertNotNull(metrics);
+        assertEquals("https://biodiversity.org.au/afd/taxa/18997fe9-4fc7-4327-b962-e921cfee45c7", metrics.getResult().getLsid());
+        assertEquals("https://biodiversity.org.au/afd/taxa/4c582775-3afe-4076-b919-3251f515e7c1", metrics.getResult().getAcceptedLsid());
         assertEquals(MatchType.EXACT, metrics.getResult().getMatchType());
     }
 

--- a/ala-name-matching-search/src/test/java/au/org/ala/names/search/AutocompleteTest.java
+++ b/ala-name-matching-search/src/test/java/au/org/ala/names/search/AutocompleteTest.java
@@ -53,7 +53,7 @@ public class AutocompleteTest {
         Map first = results.get(0);
         assertEquals("Samadera sp. Mary River", first.get("name"));
         Map second = results.get(1);
-        assertEquals("Mary River cod", second.get("commonname"));
+        assertEquals("Mary River Cod", second.get("commonname"));
         assertEquals("Maccullochella mariensis", second.get("name"));
         Map third = results.get(2);
         assertEquals("Mary River turtle", third.get("commonname"));
@@ -153,10 +153,6 @@ public class AutocompleteTest {
         assertTrue(results.size() > 2);
         Optional<Map> syn = results.stream().filter(r -> "Sisyrinchium micranthum".equals(r.get("name"))).findFirst();
         assertTrue(syn.isPresent());
-        //List<Map> synonyms = (List<Map>) syn.get().get("synonymMatch");
-        //assertNotNull(synonyms);
-        //assertTrue(synonyms.size() > 0);
-        //Map synonym = synonyms.get(0);
         assertEquals("Yellow Rush Lily", syn.get().get("commonname"));
     }
 

--- a/ala-name-matching-search/src/test/java/au/org/ala/names/search/AutocompleteTest.java
+++ b/ala-name-matching-search/src/test/java/au/org/ala/names/search/AutocompleteTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static org.junit.Assert.*;
 
@@ -52,10 +53,10 @@ public class AutocompleteTest {
         Map first = results.get(0);
         assertEquals("Samadera sp. Mary River", first.get("name"));
         Map second = results.get(1);
-        assertEquals("Mary River Cod", second.get("commonname"));
+        assertEquals("Mary River cod", second.get("commonname"));
         assertEquals("Maccullochella mariensis", second.get("name"));
         Map third = results.get(2);
-        assertEquals("Mary River Turtle", third.get("commonname"));
+        assertEquals("Mary River turtle", third.get("commonname"));
         assertEquals("Elusor macrurus", third.get("name"));
     }
 
@@ -65,7 +66,7 @@ public class AutocompleteTest {
         assertNotNull(results);
         assertTrue(results.size() > 0);
         Map first = results.get(0);
-        assertEquals("Mary River Turtle", first.get("commonname"));
+        assertEquals("Mary River turtle", first.get("commonname"));
         assertEquals("Elusor macrurus", first.get("name"));
     }
 
@@ -129,8 +130,8 @@ public class AutocompleteTest {
         List<Map> results = searcher.autocomplete("Rossi", 10, true);
         assertNotNull(results);
         assertTrue(results.size() > 0);
-        Map first = results.get(0);
-        assertEquals("Pleurotomella rossi", first.get("name"));
+        assertTrue(results.stream().anyMatch(r -> "Pleurotomella rossi".equals(r.get("name"))));
+        assertTrue(results.stream().anyMatch(r -> "Metacineta rossica".equals(r.get("name"))));
     }
 
 
@@ -150,13 +151,13 @@ public class AutocompleteTest {
         List<Map> results = searcher.autocomplete("rush li", 10, true);
         assertNotNull(results);
         assertTrue(results.size() > 2);
-        Map syn = results.get(2);
-        assertEquals("Sisyrinchium rosulatum", syn.get("name"));
-        List<Map> synonyms = (List<Map>) syn.get("synonymMatch");
-        assertNotNull(synonyms);
-        assertTrue(synonyms.size() > 0);
-        Map synonym = synonyms.get(0);
-        assertEquals("Yellow Rush Lily", synonym.get("commonname"));
+        Optional<Map> syn = results.stream().filter(r -> "Sisyrinchium micranthum".equals(r.get("name"))).findFirst();
+        assertTrue(syn.isPresent());
+        //List<Map> synonyms = (List<Map>) syn.get().get("synonymMatch");
+        //assertNotNull(synonyms);
+        //assertTrue(synonyms.size() > 0);
+        //Map synonym = synonyms.get(0);
+        assertEquals("Yellow Rush Lily", syn.get().get("commonname"));
     }
 
 }

--- a/ala-name-matching-search/src/test/java/au/org/ala/names/search/BiocacheMatchTest.java
+++ b/ala-name-matching-search/src/test/java/au/org/ala/names/search/BiocacheMatchTest.java
@@ -376,7 +376,7 @@ public class BiocacheMatchTest {
 
     // See https://github.com/AtlasOfLivingAustralia/ala-name-matching/issues/1
     // At the moment, not able to correctly parse this out
-    @Ignore
+    //@Ignore
     @Test
     public void testSubSpeciesMarker3()  {
         try {

--- a/ala-name-matching-search/src/test/java/au/org/ala/names/search/VernacularMatchTest.java
+++ b/ala-name-matching-search/src/test/java/au/org/ala/names/search/VernacularMatchTest.java
@@ -41,7 +41,7 @@ public class VernacularMatchTest {
     @org.junit.BeforeClass
     public static void init() throws Exception {
         searcher = new ALANameSearcher("/data/lucene/namematching-20210811-2");
-     }
+    }
 
     @Test
     public void testVernacular1() throws Exception {
@@ -54,7 +54,7 @@ public class VernacularMatchTest {
         assertEquals(expectedLsid, result.getLsid());
     }
 
-    //@Ignore // Requires indidgenous names
+    //@Ignore // Requires indigenous names
     @Test
     public void testVernacular2() throws Exception {
         String name = "Dhulwa";
@@ -102,7 +102,7 @@ public class VernacularMatchTest {
     }
 
 
-    @Ignore // Requires indidgenous names
+    @Ignore // Requires additonal indidgenous names
     @Test
     public void testVernacular6() throws Exception {
         String name = "Dharaban";
@@ -126,6 +126,127 @@ public class VernacularMatchTest {
         assertNotNull(result);
         assertEquals(MatchType.VERNACULAR, result.getMatchType());
         assertEquals(expectedLsid, result.getLsid());
+    }
+
+
+    // Multiple names
+    @Test
+    public void testVernacular8() {
+        String name = "White-spotted Skate";
+        NameSearchResult result = this.searcher.searchForCommonName(name);
+        assertNotNull(result);
+        String lsid = result.getLsid();
+        assertEquals("https://biodiversity.org.au/afd/taxa/e8e7ae96-a352-438c-8893-045ab8d5ce97", lsid);
+    }
+
+    // Conservation NSW
+    @Test
+    public void testVernacular9() {
+        String name = "Velvet Wattle";
+        NameSearchResult result = this.searcher.searchForCommonName(name);
+        assertNull(result); // Multiple possibilties
+        name = "Yass Daisy";
+        result = this.searcher.searchForCommonName(name);
+        assertNotNull(result);
+        String lsid = result.getLsid();
+        assertEquals("https://id.biodiversity.org.au/node/apni/2910323", lsid);
+    }
+
+    // Conservation Qld
+    @Test
+    public void testVernacular10() {
+        String name = "Red Wattlebird";
+        NameSearchResult result = this.searcher.searchForCommonName(name);
+        assertNotNull(result);
+        String lsid = result.getLsid();
+        assertEquals("https://biodiversity.org.au/afd/taxa/8204979f-5302-41ea-943f-01d3c420f7bb", lsid);
+    }
+
+
+    // Conservation Aus
+    @Test
+    public void testVernacular11() {
+        String name = "Mary River Turtle";
+        NameSearchResult result = this.searcher.searchForCommonName(name);
+        assertNotNull(result);
+        String lsid = result.getLsid();
+        assertEquals("https://biodiversity.org.au/afd/taxa/d315deea-822c-4f2c-b439-da33d6af5fd6", lsid);
+    }
+    
+    // Sensitive NT
+    @Test
+    public void testVernacular12() {
+        String name = "Atlas Moth";
+        NameSearchResult result = this.searcher.searchForCommonName(name);
+        assertNotNull(result);
+        String lsid = result.getLsid();
+        assertEquals("https://biodiversity.org.au/afd/taxa/8a05008e-53e8-4773-855a-43ac29cc6056", lsid);
+    }
+
+    // Sensitive Qld
+    @Test
+    public void testVernacular13() {
+        String name = "Ravine Orchid";
+        NameSearchResult result = this.searcher.searchForCommonName(name);
+        assertNotNull(result);
+        String lsid = result.getLsid();
+        assertEquals("https://id.biodiversity.org.au/taxon/apni/51413233", lsid);
+    }
+
+    // Sensitive SA
+    @Test
+    public void testVernacular14() {
+        String name = "Osprey";
+        NameSearchResult result = this.searcher.searchForCommonName(name);
+        assertNull(result); // Multiple possibilitie
+        name = "Swamp Bunnies";
+        result = this.searcher.searchForCommonName(name);
+        assertNotNull(result);
+        String lsid = result.getLsid();
+        assertEquals("https://id.biodiversity.org.au/taxon/apni/51290607", lsid);
+    }
+
+    // Sensitive WA
+    @Test
+    public void testVernacular15() {
+        String name = "Rakali";
+        NameSearchResult result = this.searcher.searchForCommonName(name);
+        assertNotNull(result);
+        String lsid = result.getLsid();
+        assertEquals("https://biodiversity.org.au/afd/taxa/9baa55f2-69c1-486c-91f7-f96e58b7c945", lsid);
+    }
+
+    // Advisory Vic
+    @Test
+    public void testVernacular16() {
+        String name = "Robust Greenhood";
+        NameSearchResult result = this.searcher.searchForCommonName(name);
+        assertNotNull(result);
+        String lsid = result.getLsid();
+        assertEquals("https://id.biodiversity.org.au/taxon/apni/51412430", lsid);
+    }
+
+    // Advisory Vic
+    @Test
+    public void testVernacular17() {
+        String name = "Little Tern";
+        NameSearchResult result = this.searcher.searchForCommonName(name);
+        assertNull(result); // Multiple results
+        name = "Victoria Range Stringybark";
+        result = this.searcher.searchForCommonName(name);
+        assertNotNull(result);
+        String lsid = result.getLsid();
+        assertEquals("https://id.biodiversity.org.au/node/apni/2905514", lsid);
+    }
+
+    // Invasive species
+    @Test
+    public void testVernacular18() {
+        String name = "Onion Fly";
+        NameSearchResult result = this.searcher.searchForCommonName(name);
+        assertNotNull(result);
+        String lsid = result.getLsid();
+        assertEquals("ALA_3855965", lsid);
     }
 
 }

--- a/ala-name-matching-search/src/test/java/au/org/ala/names/search/VernacularMatchTest.java
+++ b/ala-name-matching-search/src/test/java/au/org/ala/names/search/VernacularMatchTest.java
@@ -101,12 +101,10 @@ public class VernacularMatchTest {
         assertEquals(expectedLsid, result.getLsid());
     }
 
-
-    @Ignore // Requires additonal indidgenous names
     @Test
     public void testVernacular6() throws Exception {
-        String name = "Dharaban";
-        String expectedLsid = "https://id.biodiversity.org.au/node/apni/2886278";
+        String name = "A-gurruwurduk";
+        String expectedLsid = "https://biodiversity.org.au/afd/taxa/0f5df411-17dd-4719-91de-158fb1a77b27";
         NameSearchResult result = null;
 
         result = searcher.searchForCommonName(name);


### PR DESCRIPTION
Also, cleaner resolution of vernacular names, taking synonyms into account.

This extension is needed by the lists tool to be able to follow lists where the "names" are actually taxon identifiers.

Also, a fix for annoying issue https://github.com/AtlasOfLivingAustralia/ala-name-matching/issues/140