### PR TITLE
Include DocValues for integer/double fields so that they can be sorted properly.

### DIFF
--- a/ala-name-matching-builder/src/main/java/au/org/ala/names/search/ALANameIndexer.java
+++ b/ala-name-matching-builder/src/main/java/au/org/ala/names/search/ALANameIndexer.java
@@ -732,10 +732,8 @@ public class ALANameIndexer {
         NameIndexField.LSID.index(newLsid, doc);
         if(language != null) {
             NameIndexField.LANGUAGE.index(language.toLowerCase().trim(), doc);
-         }
-        if (priority != null) {
-            NameIndexField.PRIORITY.index(priority, doc);
         }
+        NameIndexField.PRIORITY.index(priority == null ? 0 : priority, doc);
 
         return doc;
     }

--- a/ala-name-matching-builder/src/test/resources/au/org/ala/names/index/locations/eml.xml
+++ b/ala-name-matching-builder/src/test/resources/au/org/ala/names/index/locations/eml.xml
@@ -56,8 +56,7 @@
     <metadata>
       <gbif>
         <dateStamp>2022-08-11T02:26:09</dateStamp>
-        <citation identifier="DR19606-20220724-20220811">The Getty Institute Vocabularies http://vocab.getty.edu/&#13;
-Published under the Open Data Commons Attribution Licence (OGC-By) 1.0 https://opendatacommons.org/licenses/by/1-0/, The Atlas of Living Australia, 2022-07-24</citation>
+        <citation identifier="DR19606-20220724-20220811">The Getty Institute Vocabularies http://vocab.getty.edu/  Published under the Open Data Commons Attribution Licence (OGC-By) 1.0 https://opendatacommons.org/licenses/by/1-0/, The Atlas of Living Australia, 2022-07-24</citation>
       </gbif>
     </metadata>
   </additionalMetadata>

--- a/ala-name-matching-search/src/test/java/au/org/ala/names/search/AutocompleteTest.java
+++ b/ala-name-matching-search/src/test/java/au/org/ala/names/search/AutocompleteTest.java
@@ -86,7 +86,7 @@ public class AutocompleteTest {
         assertNotNull(results);
         assertTrue(results.size() > 0);
         Map first = results.get(0);
-        assertEquals("Acacia dodonaeifolia", first.get("name"));
+        assertEquals("Acacia dampieri", first.get("name"));
     }
 
     @Test

--- a/ala-name-matching-search/src/test/java/au/org/ala/names/search/BiocacheMatchTest.java
+++ b/ala-name-matching-search/src/test/java/au/org/ala/names/search/BiocacheMatchTest.java
@@ -108,7 +108,7 @@ public class BiocacheMatchTest {
         cl.setGenus("Graphis");
         cl.setSpecificEpithet("notreallyaname");
         MetricsResultDTO metrics = searcher.searchForRecordMetrics(cl, true);
-        assertEquals("NZOR-6-132826", metrics.getResult().getLsid()); // Can't find Graphis homonym so gets Graphidaceae
+        assertEquals("NZOR-6-122770", metrics.getResult().getLsid()); // Now finds Graphis
     }
 
     @Test


### PR DESCRIPTION
Note that name search uses the boost values in the name/document rather than the priority directly and so does not contain a sort in the search.